### PR TITLE
Add "rollup filters" to support unique counts

### DIFF
--- a/src/main/java/com/urbanairship/datacube/ReadAddressBuilder.java
+++ b/src/main/java/com/urbanairship/datacube/ReadAddressBuilder.java
@@ -12,6 +12,9 @@ public class ReadAddressBuilder {
     }
 
     public <O> ReadAddressBuilder at(Dimension<?> dimension, O coordinate) {
+        if(dimension.isBucketed()) {
+            throw new IllegalArgumentException("This dimension requires you to specify a bucketType");
+        }
         this.at(dimension, BucketType.IDENTITY, coordinate);
         return this;
     }

--- a/src/main/java/com/urbanairship/datacube/RollupFilter.java
+++ b/src/main/java/com/urbanairship/datacube/RollupFilter.java
@@ -1,0 +1,18 @@
+package com.urbanairship.datacube;
+
+import com.google.common.base.Optional;
+
+public interface RollupFilter {
+    /**
+     * A low-level hook for intercepting writes after bucketing before they are applied to the
+     * cube. This is intended to support unique counts; an implementation might provide a
+     * RollupFilter implementation that checks whether a given user has already been counted.
+     * @param address one of the after-bucketing addresses in the cube that will receive a write.
+     * This address consists of one or more (bucketType,bucket) pairs.
+     * @param attachment if the writer passed an object to 
+     * {@link WriteBuilder#attachForRollupFilter(RollupFilter, Object)}, it will be passed to
+     * the RollupFilter. This is a good way to provide a userid to check for uniqueness, for
+     * example.
+     */
+    public boolean filter(Address address, Optional<Object> attachment);
+}

--- a/src/main/java/com/urbanairship/datacube/WriteBuilder.java
+++ b/src/main/java/com/urbanairship/datacube/WriteBuilder.java
@@ -9,7 +9,8 @@ import com.google.common.collect.Multimap;
 public class WriteBuilder {
     private final Multimap<Dimension<?>,BucketType> bucketsOfInterest;
     private final Map<DimensionAndBucketType,byte[]> buckets = Maps.newHashMap(); 
-
+    private Map<RollupFilter,Object> filterAttachments = Maps.newHashMap();
+    
     public WriteBuilder(DataCube<?> cube) {
         this.bucketsOfInterest = cube.getBucketsOfInterest();
     }
@@ -30,6 +31,19 @@ public class WriteBuilder {
             buckets.put(new DimensionAndBucketType(dimension, bucketType), bucket);
         }
         return this;
+    }
+    
+    /**
+     * Attach an arbitrary object to this write. This object will be presented to the rollup
+     * filters, so they can use it to make filtering decisions.
+     */
+    public WriteBuilder attachForRollupFilter(RollupFilter rollupFilter, Object attachment) {
+        filterAttachments.put(rollupFilter, attachment);
+        return this;
+    }
+    
+    Map<RollupFilter,Object> getRollupFilterAttachments() {
+        return filterAttachments;
     }
     
     public Map<DimensionAndBucketType,byte[]> getBuckets() {

--- a/src/main/java/com/urbanairship/datacube/ops/LongOp.java
+++ b/src/main/java/com/urbanairship/datacube/ops/LongOp.java
@@ -72,7 +72,7 @@ public class LongOp implements Op {
         return Long.toString(val);
     }
     
-    public long getValue() {
+    public long getLong() {
         return val;
     }
 }

--- a/src/test/java/com/urbanairship/datacube/BackfillExampleTest.java
+++ b/src/test/java/com/urbanairship/datacube/BackfillExampleTest.java
@@ -100,7 +100,7 @@ public class BackfillExampleTest {
             Optional<LongOp> countOpt = dataCubeIo.get(new ReadAddressBuilder(dataCube)
                 .at(timeDimension, HourDayMonthBucketer.days, day));
             if(countOpt.isPresent()) {
-                return countOpt.get().getValue();
+                return countOpt.get().getLong();
             } else {
                 return 0L;
             }
@@ -110,7 +110,7 @@ public class BackfillExampleTest {
             Optional<LongOp> countOpt = dataCubeIo.get(new ReadAddressBuilder(dataCube)
                 .at(timeDimension, HourDayMonthBucketer.hours, hour));
             if(countOpt.isPresent()) {
-                return countOpt.get().getValue();
+                return countOpt.get().getLong();
             } else {
                 return 0L;
             }

--- a/src/test/java/com/urbanairship/datacube/CompleteExampleTest.java
+++ b/src/test/java/com/urbanairship/datacube/CompleteExampleTest.java
@@ -186,7 +186,7 @@ public class CompleteExampleTest {
             if(!opt.isPresent()) {
                 return 0;
             } else {
-                return opt.get().getValue();
+                return opt.get().getLong();
             }
         }
         
@@ -198,7 +198,7 @@ public class CompleteExampleTest {
             if(!opt.isPresent()) {
                 return 0L;
             } else {
-                return opt.get().getValue();
+                return opt.get().getLong();
             }
         }
         
@@ -210,7 +210,7 @@ public class CompleteExampleTest {
             if(!opt.isPresent()) {
                 return 0L;
             } else {
-                return opt.get().getValue();
+                return opt.get().getLong();
             }
         }
         
@@ -221,7 +221,7 @@ public class CompleteExampleTest {
             if(!opt.isPresent()) {
                 return 0L;
             } else {
-                return opt.get().getValue();
+                return opt.get().getLong();
             }
         }
         
@@ -230,7 +230,7 @@ public class CompleteExampleTest {
             if(!opt.isPresent()) {
                 return 0L;
             } else {
-                return opt.get().getValue();
+                return opt.get().getLong();
             }
         }
         
@@ -243,7 +243,7 @@ public class CompleteExampleTest {
             if(!opt.isPresent()) {
                 return 0L;
             } else {
-                return opt.get().getValue();
+                return opt.get().getLong();
             }
         }
     }

--- a/src/test/java/com/urbanairship/datacube/DbHarnessTests.java
+++ b/src/test/java/com/urbanairship/datacube/DbHarnessTests.java
@@ -60,20 +60,20 @@ public class DbHarnessTests {
                 .at(time, HourDayMonthBucketer.hours, now)
                 .at(zipcode, "97201"));
         Assert.assertTrue(thisHourCount.isPresent());
-        Assert.assertEquals(5L, thisHourCount.get().getValue());
+        Assert.assertEquals(5L, thisHourCount.get().getLong());
         
         // Read back the value we wrote for the other hour, should be 10
         Optional<LongOp> differentHourCount = cubeIo.get(new ReadAddressBuilder(cube)
                 .at(time, HourDayMonthBucketer.hours, differentHour)
                 .at(zipcode, "97201"));
         Assert.assertTrue(differentHourCount.isPresent());
-        Assert.assertEquals(10L, differentHourCount.get().getValue());
+        Assert.assertEquals(10L, differentHourCount.get().getLong());
 
         // The total for today should be the sum of the two increments
         Optional<LongOp> todayCount = cubeIo.get(new ReadAddressBuilder(cube)
                 .at(time, HourDayMonthBucketer.days, now)
                 .at(zipcode, "97201"));
         Assert.assertTrue(todayCount.isPresent());
-        Assert.assertEquals(15L, todayCount.get().getValue());
+        Assert.assertEquals(15L, todayCount.get().getLong());
     }
 }

--- a/src/test/java/com/urbanairship/datacube/HBaseBackfillIntegrationTest.java
+++ b/src/test/java/com/urbanairship/datacube/HBaseBackfillIntegrationTest.java
@@ -78,7 +78,7 @@ public class HBaseBackfillIntegrationTest {
             Optional<LongOp> countOpt = dataCubeIo.get(new ReadAddressBuilder(oldCube)
                 .at(timeDimension, HourDayMonthBucketer.days, day));
             if(countOpt.isPresent()) {
-                return countOpt.get().getValue();
+                return countOpt.get().getLong();
             } else {
                 return 0L;
             }
@@ -88,7 +88,7 @@ public class HBaseBackfillIntegrationTest {
             Optional<LongOp> countOpt = dataCubeIo.get(new ReadAddressBuilder(oldCube)
                 .at(timeDimension, HourDayMonthBucketer.hours, hour));
             if(countOpt.isPresent()) {
-                return countOpt.get().getValue();
+                return countOpt.get().getLong();
             } else {
                 return 0L;
             }
@@ -116,7 +116,7 @@ public class HBaseBackfillIntegrationTest {
                     .at(timeDimension, HourDayMonthBucketer.hours, hour)
                     .at(colorDimension, color));
             if(countOpt.isPresent()) {
-                return countOpt.get().getValue();
+                return countOpt.get().getLong();
             } else {
                 return 0L;
             }
@@ -126,7 +126,7 @@ public class HBaseBackfillIntegrationTest {
             Optional<LongOp> countOpt = dataCubeIo.get(new ReadAddressBuilder(newCube)
                 .at(timeDimension, HourDayMonthBucketer.hours, hour));
             if(countOpt.isPresent()) {
-                return countOpt.get().getValue();
+                return countOpt.get().getLong();
             } else {
                 return 0L;
             }
@@ -136,7 +136,7 @@ public class HBaseBackfillIntegrationTest {
             Optional<LongOp> countOpt = dataCubeIo.get(new ReadAddressBuilder(newCube)
                 .at(timeDimension, HourDayMonthBucketer.days, day));
             if(countOpt.isPresent()) {
-                return countOpt.get().getValue();
+                return countOpt.get().getLong();
             } else {
                 return 0L;
             }

--- a/src/test/java/com/urbanairship/datacube/HBaseBackfillerTest.java
+++ b/src/test/java/com/urbanairship/datacube/HBaseBackfillerTest.java
@@ -201,9 +201,9 @@ public class HBaseBackfillerTest {
         // After everyhing's done, the two writes that occurred concurrently with the backfill
         // should be seen in the live table. coord1 should be 5+6=11 and coord2 should be 7.
         Assert.assertEquals(11L, 
-                cubeIo.get(new ReadAddressBuilder(cube).at(onlyDimension, "coord1")).get().getValue());
+                cubeIo.get(new ReadAddressBuilder(cube).at(onlyDimension, "coord1")).get().getLong());
         Assert.assertEquals(7L, 
-                cubeIo.get(new ReadAddressBuilder(cube).at(onlyDimension, "coord2")).get().getValue());
+                cubeIo.get(new ReadAddressBuilder(cube).at(onlyDimension, "coord2")).get().getLong());
     }
 
     public static void assertTablesEqual(Configuration conf, byte[] leftTableName, 

--- a/src/test/java/com/urbanairship/datacube/TestUtil.java
+++ b/src/test/java/com/urbanairship/datacube/TestUtil.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
 
-public class TestUtil {
+public abstract class TestUtil {
     public static final String HADOOP_LOG_DIR = "/tmp/datacube_hadoop_logs";
     
     public static void preventMiniClusterNPE(HBaseTestingUtility hbaseTestUtil) {

--- a/src/test/java/com/urbanairship/datacube/UniqueCountsExample.java
+++ b/src/test/java/com/urbanairship/datacube/UniqueCountsExample.java
@@ -1,0 +1,169 @@
+package com.urbanairship.datacube;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ConcurrentMap;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Multimap;
+import com.urbanairship.datacube.DbHarness.CommitType;
+import com.urbanairship.datacube.bucketers.HourDayMonthBucketer;
+import com.urbanairship.datacube.dbharnesses.MapDbHarness;
+import com.urbanairship.datacube.idservices.MapIdService;
+import com.urbanairship.datacube.ops.LongOp;
+
+/**
+ * An example of counting unique users over multiple time intervals. 
+ */
+public class UniqueCountsExample {
+    static class Event {
+        private final DateTime time;
+        private final String username;
+        
+        public Event(DateTime time, String username) {
+            this.time = time;
+            this.username = username;
+        }
+    }
+    
+    static Dimension<DateTime> timeDimension = new Dimension<DateTime>("time",
+            new HourDayMonthBucketer(), false, 8);
+    
+    // For a given hour/day/month, which users have we already seen?
+    static Multimap<DateTime,String> seenUsersByHour = HashMultimap.create();
+    static Multimap<DateTime,String> seenUsersByDay = HashMultimap.create();
+    static Multimap<DateTime,String> seenUsersByMonth = HashMultimap.create();
+    
+    /**
+     * This is a RollupFilter that will decline to count any events if the username was already
+     * seen for the given time interval.
+     */
+    static RollupFilter uniqueCountFilter = new RollupFilter() {
+        @Override
+        public boolean filter(Address address, Optional<Object> attachment) {
+            Assert.assertTrue(attachment.isPresent());
+            String username = (String)attachment.get();
+            
+            byte[] timestampBytes = address.get(timeDimension).bucket;
+            DateTime dateTime = new DateTime(Util.bytesToLong(timestampBytes), DateTimeZone.UTC);
+             
+            Multimap<DateTime,String> checkUniquenessMap;
+            BucketType bucketType = address.get(timeDimension).bucketType; 
+            if(bucketType == HourDayMonthBucketer.hours) {
+                checkUniquenessMap = seenUsersByHour;
+            } else if(bucketType == HourDayMonthBucketer.days) {
+                checkUniquenessMap = seenUsersByDay;
+            } else if(bucketType == HourDayMonthBucketer.months) {
+                checkUniquenessMap = seenUsersByMonth;
+            } else {
+                throw new AssertionError("Unexpected bucket type");
+            }
+            
+            boolean firstTimeSeen = checkUniquenessMap.put(dateTime, username);
+            return firstTimeSeen;
+        }
+    };
+    
+    /**
+     * A wrapper class that hides cube manipulation behind easy-to-read function names.
+     */
+    private static class CubeWrapper {
+        private DataCube<LongOp> dataCube;
+        private DataCubeIo<LongOp> dataCubeIo;
+        
+        public CubeWrapper() {
+            
+            Rollup hourRollup = new Rollup(timeDimension, HourDayMonthBucketer.hours);
+            Rollup dayRollup = new Rollup(timeDimension, HourDayMonthBucketer.days);
+            Rollup monthRollup = new Rollup(timeDimension, HourDayMonthBucketer.months);
+            List<Rollup> rollups = ImmutableList.of(hourRollup, dayRollup, monthRollup);
+            
+            List<Dimension<?>> dims = ImmutableList.<Dimension<?>>of(timeDimension);
+            
+            dataCube = new DataCube<LongOp>(dims, rollups);
+            IdService idService = new MapIdService();
+            ConcurrentMap<BoxedByteArray,byte[]> backingMap = Maps.newConcurrentMap();
+            DbHarness<LongOp> dbHarness = new MapDbHarness<LongOp>(backingMap,LongOp.DESERIALIZER, 
+                    CommitType.READ_COMBINE_CAS, 5, idService);
+            this.dataCubeIo = new DataCubeIo<LongOp>(dataCube, dbHarness, 1);
+            
+            dataCube.addFilter(hourRollup, uniqueCountFilter);
+            dataCube.addFilter(dayRollup, uniqueCountFilter);
+            dataCube.addFilter(monthRollup, uniqueCountFilter);
+        }
+        
+        public void put(Event event) throws IOException {
+            WriteBuilder writeBuilder = new WriteBuilder(dataCube)
+                .at(timeDimension, event.time)
+                .attachForRollupFilter(uniqueCountFilter, event.username);
+            dataCubeIo.write(new LongOp(1), writeBuilder);
+        }
+        
+        public long getUniqueUsersForHour(DateTime timestamp) throws IOException {
+            Optional<LongOp> countOpt = dataCubeIo.get(new ReadAddressBuilder(dataCube)
+                .at(timeDimension, HourDayMonthBucketer.hours, timestamp));
+            if(countOpt.isPresent()) {
+                return countOpt.get().getLong();
+            } else {
+                return 0L;
+            }
+        }
+
+        public long getUniqueUsersForDay(DateTime timestamp) throws IOException {
+            Optional<LongOp> countOpt = dataCubeIo.get(new ReadAddressBuilder(dataCube)
+                .at(timeDimension, HourDayMonthBucketer.days, timestamp));
+            if(countOpt.isPresent()) {
+                return countOpt.get().getLong();
+            } else {
+                return 0L;
+            }
+        }
+        public long getUniqueUsersForMonth(DateTime timestamp) throws IOException {
+            Optional<LongOp> countOpt = dataCubeIo.get(new ReadAddressBuilder(dataCube)
+                .at(timeDimension, HourDayMonthBucketer.months, timestamp));
+            if(countOpt.isPresent()) {
+                return countOpt.get().getLong();
+            } else {
+                return 0L;
+            }
+        }
+    }
+    
+    @Test
+    public void test() throws Exception {
+        DateTime monthBegin = new DateTime(DateTimeZone.UTC).withMillisOfDay(0).withDayOfMonth(1);
+        List<Event> events = ImmutableList.of(
+                new Event(monthBegin.plusHours(1).plusMinutes(1), "bob"),
+                new Event(monthBegin.plusHours(1).plusMinutes(2), "bob"),
+                new Event(monthBegin.plusHours(1).plusMinutes(3), "frank"),
+                new Event(monthBegin.plusHours(5).plusMinutes(2), "bob"),
+                new Event(monthBegin.minusHours(1).plusMinutes(10), "bob"),
+                new Event(monthBegin.minusHours(1).plusMinutes(5), "frank"),
+                new Event(monthBegin.minusHours(1).plusMinutes(30), "frank"));
+        
+        CubeWrapper cubeWrapper = new CubeWrapper();
+        
+        for(Event event: events) {
+            cubeWrapper.put(event);
+        }
+        
+        Assert.assertEquals(2L, cubeWrapper.getUniqueUsersForHour(monthBegin.plusHours(1)));
+        Assert.assertEquals(1L, cubeWrapper.getUniqueUsersForHour(monthBegin.plusHours(5)));
+        Assert.assertEquals(2L, cubeWrapper.getUniqueUsersForHour(monthBegin.minusHours(1)));
+        
+        Assert.assertEquals(2L, cubeWrapper.getUniqueUsersForDay(monthBegin));
+        Assert.assertEquals(2L, cubeWrapper.getUniqueUsersForDay(monthBegin.minusDays(1)));
+        
+        Assert.assertEquals(2L, cubeWrapper.getUniqueUsersForMonth(monthBegin));
+        Assert.assertEquals(2L, cubeWrapper.getUniqueUsersForMonth(monthBegin.minusMonths(1)));
+    }
+}


### PR DESCRIPTION
When counting "the number of unique X" we need some way of checking whether a particular entity X has already been counted. So we add the idea of a RollupFilter that the caller can provide to check if this is the first time that X has been seen.
