### PR TITLE
Add flushing of batches based on age

### DIFF
--- a/src/main/java/com/urbanairship/datacube/DataCubeIo.java
+++ b/src/main/java/com/urbanairship/datacube/DataCubeIo.java
@@ -14,23 +14,39 @@ public class DataCubeIo<T extends Op> {
     private final DbHarness<T> db;
     private final DataCube<T> cube;
     private final int batchSize;
-
+    private final long maxBatchAgeMs;
+    
     private Batch<T> batchInProgress = new Batch<T>();
-    private int numUpdatesSinceFlush = 0;
-
+    private long batchStartTimeMs;
+    
     private final Object lock = new Object();
     
     public DataCubeIo(DataCube<T> cube, DbHarness<T> db, int batchSize) {
+        this(cube, db, batchSize, Long.MAX_VALUE);
+    }
+    
+    /**
+     * @param batchSize if after doing a write the number of rows to be written to the database
+     * exceeds this number, a flush will be done.
+     * @param maxBatchAgeMs if after doing a write the batch's oldest write was more than this long ago,
+     * a flush will be done. This is not a hard ceiling on the age of writes in the batch, because the
+     * batch will not be flushed until the *next* write arrives after the timeout.
+     */
+    public DataCubeIo(DataCube<T> cube, DbHarness<T> db, int batchSize, long maxBatchAgeMs) {
         this.cube = cube;
         this.db = db;
         this.batchSize = batchSize;
+        this.maxBatchAgeMs = maxBatchAgeMs;
     }
     
     private void updateBatchInMemory(WriteBuilder writeBuilder, T op) {
         Batch<T> newBatch = cube.getWrites(writeBuilder, op);
         synchronized (lock) {
+            if(batchInProgress.getMap().isEmpty()) {
+                // Start the timer for this batch, it should be flushed when it becomes old
+                batchStartTimeMs = System.currentTimeMillis();
+            }
             batchInProgress.putAll(newBatch);
-            numUpdatesSinceFlush++;
         }
     }
     
@@ -45,7 +61,15 @@ public class DataCubeIo<T extends Op> {
         updateBatchInMemory(c, op);
         
         synchronized (lock) {
-            if(numUpdatesSinceFlush >= batchSize) {
+            boolean shouldFlush = false;
+            
+            if(batchInProgress.getMap().size() >= batchSize) {
+                shouldFlush = true;
+            } else if(System.currentTimeMillis() > batchStartTimeMs + maxBatchAgeMs) {
+                shouldFlush = true;
+            }
+            
+            if(shouldFlush) {
                 flush();
             }
         }
@@ -70,7 +94,6 @@ public class DataCubeIo<T extends Op> {
             // We hold the lock while doing database IO. If the DB takes a long time,
             // then other threads may block for a long time.
             db.runBatch(batchInProgress);
-            numUpdatesSinceFlush = 0;
             batchInProgress = new Batch<T>();
         }
     }

--- a/src/test/java/com/urbanairship/datacube/TimedFlushTest.java
+++ b/src/test/java/com/urbanairship/datacube/TimedFlushTest.java
@@ -1,0 +1,57 @@
+package com.urbanairship.datacube;
+
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import com.urbanairship.datacube.DbHarness.CommitType;
+import com.urbanairship.datacube.bucketers.EnumToOrdinalBucketer;
+import com.urbanairship.datacube.dbharnesses.MapDbHarness;
+import com.urbanairship.datacube.idservices.MapIdService;
+import com.urbanairship.datacube.ops.LongOp;
+
+/**
+ * Test that timed flushing of batches works.
+ */
+public class TimedFlushTest {
+    
+    enum Color {RED, BLUE};
+    
+    @Test
+    public void test() throws Exception {
+        Dimension<Color> colorDimension = new Dimension<Color>("color", new EnumToOrdinalBucketer<Color>(1), false, 1);
+        Rollup colorRollup = new Rollup(colorDimension);
+        IdService idService = new MapIdService();
+        ConcurrentMap<BoxedByteArray,byte[]> backingMap = Maps.newConcurrentMap();
+        DbHarness<LongOp> dbHarness = new MapDbHarness<LongOp>(backingMap, 
+                new LongOp.LongOpDeserializer(), CommitType.READ_COMBINE_CAS, 3, idService);
+        
+        DataCube<LongOp> cube = new DataCube<LongOp>(ImmutableList.<Dimension<?>>of(colorDimension), 
+                ImmutableList.of(colorRollup));
+        DataCubeIo<LongOp> cubeIo = new DataCubeIo<LongOp>(cube, dbHarness, Integer.MAX_VALUE,
+                TimeUnit.SECONDS.toMillis(1));
+        
+        // Immediately after the first write, the write should be hanging out in the batch and not yet 
+        // written to the backing dbHarness.
+        cubeIo.write(new LongOp(1), new WriteBuilder(cube).at(colorDimension, Color.RED));
+        Assert.assertFalse(cubeIo.get(new ReadAddressBuilder(cube).at(colorDimension, Color.RED)).isPresent());
+        
+        // If we wait one second for the batch timeout to expire and write again, both writes should
+        // be flushed to the backing dbHarness.
+        Thread.sleep(1001);
+        cubeIo.write(new LongOp(1), new WriteBuilder(cube).at(colorDimension, Color.RED));
+        Assert.assertEquals(2, 
+                cubeIo.get(new ReadAddressBuilder(cube).at(colorDimension, Color.RED)).get().getLong());
+        
+        // If we do another write, it should not be flushed to the database since it's part of a new
+        // batch whose timeout has not yet expired.
+        cubeIo.write(new LongOp(1), new WriteBuilder(cube).at(colorDimension, Color.RED));
+        Assert.assertEquals(2, 
+                cubeIo.get(new ReadAddressBuilder(cube).at(colorDimension, Color.RED)).get().getLong());
+        
+    }
+}


### PR DESCRIPTION
Add the ability to flush writes to the database if they hang out in memory for too long. This limits the damage of a crashed server and improves the recency of the data in some cases.
