### PR TITLE
ResultScanner to resume after scanner timeout

### DIFF
--- a/src/main/java/com/urbanairship/datacube/AutoResumeResultScanner.java
+++ b/src/main/java/com/urbanairship/datacube/AutoResumeResultScanner.java
@@ -1,0 +1,169 @@
+package com.urbanairship.datacube;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+import org.apache.hadoop.hbase.client.HTableInterface;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.client.ScannerTimeoutException;
+import org.apache.hadoop.hbase.regionserver.LeaseException;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+/**
+ * A ResultScanner that will restart if scan times out on the region servier. This will
+ * happen if the client doesn't ask for more results for a certain length of time.
+ * 
+ * This is particularly useful when doing a merge-join, when one iterator input may go unused for
+ * a long time.
+ */
+@NotThreadSafe
+public class AutoResumeResultScanner implements ResultScanner {
+    public static final Logger log = LogManager.getLogger(AutoResumeResultScanner.class);
+    
+    private final HTableInterface hTable;
+    private final Scan scan;
+
+    private ResultScanner resultScanner = null;
+    private Result[] currentBatch = null;
+    private int nextBatchIndex = 0;
+    private Result resumeAtResult = null;
+    private int numRestarts = 0;
+
+    public AutoResumeResultScanner(HTableInterface hTable, Scan scan) {
+        this.hTable = hTable;
+        this.scan = scan;
+    }
+
+    @Override
+    public Iterator<Result> iterator() {
+        // Essentially copied from HBase's ClientScanner.iterator()
+        return new Iterator<Result>() {
+            Result next = null;
+
+            @Override
+            public boolean hasNext() {
+                if (next == null) {
+                    try {
+                        next = AutoResumeResultScanner.this.next();
+                        return next != null;
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+                return true;
+            }
+
+            @Override
+            public Result next() {
+                if (!hasNext()) {
+                    return null;
+                }
+
+                Result temp = next;
+                next = null;
+                return temp;
+            }
+
+            @Override
+            public void remove() {
+                throw new UnsupportedOperationException();
+            }
+        };
+    }
+    
+    private int batchSize() {
+        return Math.max(1, scan.getCaching());
+    }
+
+    /**
+     * @return a Result, or null if the scan is finished.
+     */
+    @Override
+    public Result next() throws IOException {
+        boolean shouldReadNewBatch = false;
+        if(currentBatch == null) {
+            // Fresh start, no result batch has yet been loaded. Get one.
+            resultScanner = hTable.getScanner(scan);
+            currentBatch = new Result[batchSize()];
+            shouldReadNewBatch = true;
+        } else if (nextBatchIndex == currentBatch.length) {
+            // We have a result batch, but we already used them all. Get a new batch.
+            shouldReadNewBatch = true;
+        }
+
+        if(shouldReadNewBatch) {
+            boolean shouldRestartScan = false;
+            try {
+                currentBatch = resultScanner.next(batchSize());
+                nextBatchIndex = 0;
+            } catch (LeaseException e) {
+                log.warn("Got LeaseException, restarting scan (recoverable)", e);
+                shouldRestartScan = true;
+            } catch (ScannerTimeoutException e) {
+                log.warn("Got ScannerTimeoutException, restarting scan (recoverable)", e);
+                shouldRestartScan = true;
+            }
+            
+            if(shouldRestartScan) { 
+                // There was a timeout exception while scanning. Get a new ResultScanner starting
+                // from the last row seen.
+                Scan resumeScan = new Scan(scan);
+                if(resumeAtResult != null) {
+                    resumeScan.setStartRow(resumeAtResult.getRow());
+                }
+                
+                resultScanner = hTable.getScanner(resumeScan);
+                if(resumeAtResult != null) {
+                    // We're resuming a scan. Skip the first Result, which we already returned.
+                    resultScanner.next();
+                }
+                nextBatchIndex = 0;
+                currentBatch = resultScanner.next(batchSize());
+                numRestarts++;
+            }
+        }
+        
+        if(nextBatchIndex == currentBatch.length) {
+            resultScanner.close();
+            return null;
+        }
+        
+        resumeAtResult = currentBatch[nextBatchIndex++]; 
+        return resumeAtResult;  
+    }
+    
+    /**
+     * @return up to nbRows results, or empty array if scan is finished. Never returns null.
+     */
+    @Override
+    public Result[] next(int nbRows) throws IOException {
+        ArrayList<Result> returnList = new ArrayList<Result>(nbRows);
+        
+        for(int i=0; i<nbRows; i++) {
+            Result next = next();
+            if(next == null) {
+                break;
+            }
+            returnList.add(next);
+        }
+        
+        return returnList.toArray(new Result[returnList.size()]);
+    }
+
+    @Override
+    public void close() {
+        if(resultScanner != null) {
+            resultScanner.close();
+        }
+    }
+    
+    public int getNumRestarts() {
+        return numRestarts;
+    }
+}

--- a/src/test/java/com/urbanairship/datacube/AutoResumeResultScannerTest.java
+++ b/src/test/java/com/urbanairship/datacube/AutoResumeResultScannerTest.java
@@ -1,0 +1,186 @@
+package com.urbanairship.datacube;
+
+import java.util.Iterator;
+import java.util.concurrent.TimeUnit;
+
+import junit.framework.Assert;
+
+import org.apache.hadoop.hbase.client.HTable;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.Assume;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class AutoResumeResultScannerTest extends EmbeddedClusterTestAbstract {
+    
+    private static final String tableName = "myTable";
+    private static final String cfName = "myCf";
+    
+    @BeforeClass
+    public static void skipUnlessPropSet() throws Exception {
+        // Since this test takes a long time, skip it unless a certain system property is set.
+        String shouldRun = System.getProperty("datacube.runAutoResumeResultScannerTest", "false");
+        Assume.assumeTrue(Boolean.valueOf(shouldRun));
+    }
+    
+    private static HTable createSchemaAndInsertTestData() throws Exception {
+        HTable hTable;
+        if(getTestUtil().getHBaseAdmin().tableExists(tableName.getBytes())) {
+            hTable = new HTable(getTestUtil().getConfiguration(), tableName);
+        } else { 
+            hTable = getTestUtil().createTable(tableName.getBytes(), cfName.getBytes());
+        }
+        
+        for(int i=0; i<5; i++) {
+            byte[] iAsBytes = Bytes.toBytes(i);
+            Put put = new Put(iAsBytes);
+            put.add(cfName.getBytes(), iAsBytes, iAsBytes);
+            hTable.put(put);
+        }
+        return hTable;
+    }
+    
+    @Test
+    public void testWithTimeouts() throws Exception {
+        HTable hTable = createSchemaAndInsertTestData();
+        
+        Scan scan = new Scan();
+        scan.addFamily(cfName.getBytes());
+        AutoResumeResultScanner scanner = new AutoResumeResultScanner(hTable, scan);
+        
+        Assert.assertEquals(0, Bytes.toInt(scanner.next().value()));
+        Assert.assertEquals(1, Bytes.toInt(scanner.next().value()));
+        
+        // Wait for 70 seconds between 2nd the 3rd next calls. This should cause the regionserver
+        // to time out the scanner 
+        Assert.assertEquals(0, scanner.getNumRestarts());
+        Thread.sleep(TimeUnit.SECONDS.toMillis(70));
+        Assert.assertEquals(2, Bytes.toInt(scanner.next().value()));
+        Assert.assertEquals(1, scanner.getNumRestarts());
+        
+        // Pause and make the scanner resume yet again.
+        Thread.sleep(TimeUnit.SECONDS.toMillis(70));
+        Assert.assertEquals(3, Bytes.toInt(scanner.next().value()));
+        Assert.assertEquals(2, scanner.getNumRestarts());
+        Assert.assertEquals(4, Bytes.toInt(scanner.next().value()));
+        Assert.assertNull(scanner.next());  // Scan finished, should be null
+        
+        // Test that resuming a finished scan doesn't cause weirdness
+        Thread.sleep(TimeUnit.SECONDS.toMillis(70));
+        Assert.assertNull(scanner.next());  // Scan finished, should be null
+    }
+    
+    @Test
+    public void normalScanTest() throws Exception {
+        HTable hTable = createSchemaAndInsertTestData();
+        
+        Scan scan = new Scan();
+        scan.addFamily(cfName.getBytes());
+        AutoResumeResultScanner scanner = new AutoResumeResultScanner(hTable, scan);
+        
+        Assert.assertEquals(0, Bytes.toInt(scanner.next().value()));
+        Assert.assertEquals(1, Bytes.toInt(scanner.next().value()));
+        Assert.assertEquals(2, Bytes.toInt(scanner.next().value()));
+        Assert.assertEquals(3, Bytes.toInt(scanner.next().value()));
+        Assert.assertEquals(4, Bytes.toInt(scanner.next().value()));
+        Assert.assertNull(scanner.next());  // Scan finished, should be null
+        
+        Assert.assertEquals(0, scanner.getNumRestarts());
+    }
+    
+    /**
+     * Test using next(int), and not just next()
+     */
+    @Test
+    public void testMultiGet() throws Exception {
+        HTable hTable = createSchemaAndInsertTestData();
+        
+        Scan scan = new Scan();
+        scan.addFamily(cfName.getBytes());
+        AutoResumeResultScanner scanner = new AutoResumeResultScanner(hTable, scan);
+        Result[] batch;
+        
+        batch = scanner.next(2);
+        Assert.assertEquals(0, Bytes.toInt(batch[0].value()));
+        Assert.assertEquals(1, Bytes.toInt(batch[1].value()));
+        
+        Thread.sleep(TimeUnit.SECONDS.toMillis(70));
+        batch = scanner.next(2);
+        Assert.assertEquals(2, Bytes.toInt(batch[0].value()));
+        Assert.assertEquals(1, scanner.getNumRestarts());
+        Thread.sleep(TimeUnit.SECONDS.toMillis(70));
+        Assert.assertEquals(3, Bytes.toInt(batch[1].value()));
+        Assert.assertEquals(1, scanner.getNumRestarts());
+        
+        batch = scanner.next(2);
+        Assert.assertEquals(4, Bytes.toInt(batch[0].value()));
+        Assert.assertEquals(1, batch.length);
+        Assert.assertNull(scanner.next());  // Scan finished, should be null
+        Assert.assertEquals(2, scanner.getNumRestarts());
+    }
+
+    /**
+     * Test that things still work when the Scan uses setCaching() > 1.
+     */
+    @Test
+    public void testScanCaching() throws Exception {
+        HTable hTable = createSchemaAndInsertTestData();
+        
+        Scan scan = new Scan();
+        scan.setCaching(3);
+        scan.addFamily(cfName.getBytes());
+        AutoResumeResultScanner scanner = new AutoResumeResultScanner(hTable, scan);
+        
+        Assert.assertEquals(0, Bytes.toInt(scanner.next().value()));
+        Assert.assertEquals(1, Bytes.toInt(scanner.next().value()));
+        
+        // Wait for 70 seconds between 2nd the 3rd next calls. This should cause the regionserver
+        // to time out the scanner 
+        Thread.sleep(TimeUnit.SECONDS.toMillis(70));
+        Assert.assertEquals(2, Bytes.toInt(scanner.next().value()));
+        
+        // Pause and make the scanner resume yet again.
+        Thread.sleep(TimeUnit.SECONDS.toMillis(70));
+        Assert.assertEquals(3, Bytes.toInt(scanner.next().value()));
+        Assert.assertEquals(4, Bytes.toInt(scanner.next().value()));
+        Assert.assertNull(scanner.next());  // Scan finished, should be null
+        
+        // Test that resuming a finished scan doesn't cause weirdness
+        Thread.sleep(TimeUnit.SECONDS.toMillis(70));
+        Assert.assertNull(scanner.next());  // Scan finished, should be null
+    }
+    
+    @Test
+    public void testIterator() throws Exception {
+        HTable hTable = createSchemaAndInsertTestData();
+
+        Scan scan = new Scan();
+        scan.setCaching(3);
+        scan.addFamily(cfName.getBytes());
+        AutoResumeResultScanner scanner = new AutoResumeResultScanner(hTable, scan);
+        Iterator<Result> it = scanner.iterator();
+        
+        it.hasNext();
+        Assert.assertEquals(0, Bytes.toInt(it.next().value()));
+        it.hasNext();
+        Assert.assertEquals(1, Bytes.toInt(it.next().value()));
+        
+        // Wait for 70 seconds between 2nd the 3rd next calls. This should cause the regionserver
+        // to time out the scanner 
+        Thread.sleep(TimeUnit.SECONDS.toMillis(70));
+        Assert.assertEquals(2, Bytes.toInt(it.next().value()));
+        
+        // Pause and make the scanner resume yet again.
+        Thread.sleep(TimeUnit.SECONDS.toMillis(70));
+        Assert.assertEquals(3, Bytes.toInt(it.next().value()));
+        Assert.assertEquals(4, Bytes.toInt(it.next().value()));
+        Assert.assertNull(scanner.next());  // Scan finished, should be null
+        
+        // Test that resuming a finished scan doesn't cause weirdness
+        Thread.sleep(TimeUnit.SECONDS.toMillis(70));
+        Assert.assertNull(scanner.next());  // Scan finished, should be null
+    }
+}


### PR DESCRIPTION
ResultScanners timeout after 60 seconds on the region server. This is a client-side hack to keep scanning where the previous scan left off.
