### PR TITLE
Support nullable dimensions without NPE

### DIFF
--- a/src/main/java/com/urbanairship/datacube/Dimension.java
+++ b/src/main/java/com/urbanairship/datacube/Dimension.java
@@ -21,19 +21,41 @@ public class Dimension<F> {
     private final int numFieldBytes;
     private final int bucketPrefixSize;
     private final boolean isBucketed;
+    private final boolean nullable;
     
     /**
      * For dimensions where a single input bucket affects multiple buckets within that dimension.
      * For example, a single input data point might affect hourly, daily, and monthly counts.
      * 
      * @param doIdSubstitution whether to use the immutable bucket->uniqueId substition service
+     * @param the number of bytes that will be reserved in database keys for coordinates in this
+     * dimension. For example, if values in this dimension have 1000 distinct values, then you'd
+     * need ceil(log2(1000)/8)=2 bytes (1000 values can be enumerated in 10 bits, which requires 2
+     * full bytes).
      */
-    public Dimension(String name, Bucketer<F> bucketer, 
-            boolean doIdSubstitution, int fieldBytes) {
+    public Dimension(String name, Bucketer<F> bucketer, boolean doIdSubstitution, int fieldBytes) {
+        this(name, bucketer, doIdSubstitution, fieldBytes, false);
+    }
+      
+    /**
+     * For dimensions where a single input bucket affects multiple buckets within that dimension.
+     * For example, a single input data point might affect hourly, daily, and monthly counts.
+     * 
+     * @param doIdSubstitution whether to use the immutable bucket->uniqueId substition service
+     * @param the number of bytes that will be reserved in database keys for coordinates in this
+     * dimension. For example, if values in this dimension have 1000 distinct values, then you'd
+     * need ceil(log2(1000)/8)=2 bytes (1000 values can be enumerated in 10 bits, which requires 2
+     * full bytes).
+     * @param nullable false if input values are required to specify a value for this dimension,
+     * otherwise true
+     */
+    public Dimension(String name, Bucketer<F> bucketer, boolean doIdSubstitution, int fieldBytes, 
+            boolean nullable) {
         this.name = name;
         this.bucketer = bucketer;
         this.doIdSubstitution = doIdSubstitution;
         this.numFieldBytes = fieldBytes;
+        this.nullable = nullable;
         
         // Make sure all bucket unique id prefixes have the same length
         Integer previousLen = null;
@@ -80,6 +102,11 @@ public class Dimension<F> {
     public boolean getDoIdSubstitution() {
         return doIdSubstitution;
     }
+
+    public boolean isNullable() {
+        return nullable;
+    }
+    
     
     int getBucketPrefixSize() {
         return bucketPrefixSize;
@@ -88,4 +115,5 @@ public class Dimension<F> {
     boolean isBucketed() {
         return isBucketed;
     }
+    
 }

--- a/src/test/java/com/urbanairship/datacube/OmittedDimensionTest.java
+++ b/src/test/java/com/urbanairship/datacube/OmittedDimensionTest.java
@@ -1,0 +1,43 @@
+package com.urbanairship.datacube;
+
+import java.util.List;
+import java.util.concurrent.ConcurrentMap;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Maps;
+import com.urbanairship.datacube.DbHarness.CommitType;
+import com.urbanairship.datacube.bucketers.BigEndianLongBucketer;
+import com.urbanairship.datacube.dbharnesses.MapDbHarness;
+import com.urbanairship.datacube.idservices.CachingIdService;
+import com.urbanairship.datacube.idservices.MapIdService;
+import com.urbanairship.datacube.ops.LongOp;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class OmittedDimensionTest {
+
+    public static final Dimension<Long> X = new Dimension<Long>("X", new BigEndianLongBucketer(), false, 8, true);
+    public static final Dimension<Long> Y = new Dimension<Long>("Y", new BigEndianLongBucketer(), false, 8, false);
+    public static final Dimension<Long> Z = new Dimension<Long>("Z", new BigEndianLongBucketer(), false, 8, true);
+
+    @Test
+    public void testAddress() throws Exception {
+        ConcurrentMap<BoxedByteArray, byte[]> backingMap = Maps.newConcurrentMap();
+        IdService idService = new CachingIdService(4, new MapIdService());
+        DbHarness<LongOp> dbHarness = new MapDbHarness<LongOp>(backingMap, LongOp.DESERIALIZER, CommitType.OVERWRITE, idService);
+
+        List<Dimension<?>> dims = ImmutableList.<Dimension<?>>of(X, Y, Z);
+        List<Rollup> rollups = ImmutableList.of(new Rollup(X, Y), new Rollup(Y, Z));
+
+        DataCube<LongOp> cube = new DataCube<LongOp>(dims, rollups);
+
+        DataCubeIo<LongOp> cubeIo = new DataCubeIo<LongOp>(cube, dbHarness, 1, Long.MAX_VALUE, SyncLevel.FULL_SYNC);
+
+        cubeIo.writeSync(new LongOp(1), new WriteBuilder(cube).at(X, 1L).at(Y, 1L));
+        assertEquals(1L, cubeIo.get(new ReadBuilder(cube).at(X, 1L).at(Y, 1L)).get().getLong());
+
+        cubeIo.writeSync(new LongOp(1), new WriteBuilder(cube).at(Y, 1L).at(Z, 1L));
+        assertEquals(1L, cubeIo.get(new ReadBuilder(cube).at(Y, 1L).at(Z, 1L)).get().getLong());
+    }
+}


### PR DESCRIPTION
Support "nullable dimensions," where inputs can omit the coordinate for a nullable dimension. Rollups are skipped if they rely on a nullable dimension lacking an input coordinate.
