### PR TITLE
make the readCombineCas retries re-read between failures

### DIFF
--- a/src/main/java/com/urbanairship/datacube/dbharnesses/HBaseDbHarness.java
+++ b/src/main/java/com/urbanairship/datacube/dbharnesses/HBaseDbHarness.java
@@ -201,21 +201,21 @@ public class HBaseDbHarness<T extends Op> implements DbHarness<T> {
         Get get = new Get(rowKey);
         get.addColumn(cf, QUALIFIER);
 
-        Result result = WithHTable.get(pool, tableName, get);
-
-        byte[] prevSerializedOp = result.getValue(cf, QUALIFIER);
-        T combinedOp;
-        if (prevSerializedOp == null) {
-            combinedOp = newOp;
-        } else {
-            T previousOp = (T) deserializer.fromBytes(prevSerializedOp);
-            combinedOp = (T) previousOp.add(newOp);
-        }
-
-        Put put = new Put(rowKey);
-        put.add(cf, QUALIFIER, combinedOp.serialize());
-
         for (int i = 0; i < numCasTries; i++) {
+            Result result = WithHTable.get(pool, tableName, get);
+
+            byte[] prevSerializedOp = result.getValue(cf, QUALIFIER);
+            T combinedOp;
+            if (prevSerializedOp == null) {
+                combinedOp = newOp;
+            } else {
+                T previousOp = (T) deserializer.fromBytes(prevSerializedOp);
+                combinedOp = (T) previousOp.add(newOp);
+            }
+
+            Put put = new Put(rowKey);
+            put.add(cf, QUALIFIER, combinedOp.serialize());
+
             if (WithHTable.checkAndPut(pool, tableName, rowKey, cf, QUALIFIER, prevSerializedOp, put)) {
                 return; // successful write
             } else {


### PR DESCRIPTION
Currently it does this: 

  get old value 
  compute new value as (old val + update)
  for 1 .. casRetries
     try to checkAndPut(.., old val, new value) 

if the value in the table changes, this will fail between reading and updating. Retrying won't help, because we don't read a new old value. This change helps that by rereading the old value between retries. 
