### PR TITLE
Added setter

### DIFF
--- a/src/main/java/com/urbanairship/datacube/DbHarness.java
+++ b/src/main/java/com/urbanairship/datacube/DbHarness.java
@@ -41,6 +41,13 @@ public interface DbHarness<T extends Op> {
      * @throws InterruptedException 
      */
     public Optional<T> get(Address c) throws IOException, InterruptedException;
+
+    /**
+     * Overwrite value.
+     * @throws IOException
+     * @throws InterruptedException
+     */
+    public void set(Address c, T op) throws IOException, InterruptedException;
     
     public List<Optional<T>> multiGet(List<Address> addresses) throws IOException;
     

--- a/src/main/java/com/urbanairship/datacube/dbharnesses/HBaseDbHarness.java
+++ b/src/main/java/com/urbanairship/datacube/dbharnesses/HBaseDbHarness.java
@@ -248,11 +248,20 @@ public class HBaseDbHarness<T extends Op> implements DbHarness<T> {
         throw new IOException("Exhausted retries doing checkAndPut after " + numCasTries + 
                 " tries");
     }
+
+    @Override
+    public void set(Address c, T op) throws IOException, InterruptedException {
+        final byte[] rowKey = ArrayUtils.addAll(uniqueCubeName, c.toKey(idService));
+        overwrite(rowKey, op);
+    }
     
     private void overwrite(byte[] rowKey, T op) throws IOException {
         Put put = new Put(rowKey);
         put.add(cf, QUALIFIER, op.serialize());
         WithHTable.put(pool, tableName, put);
+        if(log.isDebugEnabled()) {
+            log.debug("Set of key " + Base64.encodeBase64String(rowKey));
+        }
     }
     
     private void flushBatch(Batch<T> batch) throws IOException, InterruptedException  {

--- a/src/main/java/com/urbanairship/datacube/dbharnesses/MapDbHarness.java
+++ b/src/main/java/com/urbanairship/datacube/dbharnesses/MapDbHarness.java
@@ -147,7 +147,22 @@ public class MapDbHarness<T extends Op> implements DbHarness<T> {
             return Optional.absent();
         }
     }
-    
+
+    @Override
+    public void set(Address c, T op) throws IOException, InterruptedException {
+        BoxedByteArray mapKey;
+        try {
+            mapKey = new BoxedByteArray(c.toKey(idService));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        map.put(mapKey, op.serialize());
+        if(log.isDebugEnabled()) {
+            log.debug("Set of key " + Hex.encodeHexString(mapKey.bytes));
+        }
+    }
+
     @Override
     public void flush() throws InterruptedException {
         return; // all ops are synchronously applied, nothing to do


### PR DESCRIPTION
Overwriting a value directly is a little tricky when the DbHarness is not created in OVERWRITE mode.  This makes it more direct to do so.
