### PR TITLE
Remove javadoc and maven release plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,22 +44,19 @@
       </plugin>
 
       <!-- This attaches a -javadoc.jar artifact to the build -->
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-javadoc-plugin</artifactId>
-        <configuration>
-                <additionalparam>-Xdoclint:none</additionalparam>
-        </configuration>
-        <version>2.8.1</version>
-        <executions>
-          <execution>
-            <id>attach-javadocs</id>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
+      <!-- <plugin> -->
+      <!--   <groupId>org.apache.maven.plugins</groupId> -->
+      <!--   <artifactId>maven&#45;javadoc&#45;plugin</artifactId> -->
+      <!--   <version>2.8.1</version> -->
+      <!--   <executions> -->
+      <!--     <execution> -->
+      <!--       <id>attach&#45;javadocs</id> -->
+      <!--       <goals> -->
+      <!--         <goal>jar</goal> -->
+      <!--       </goals> -->
+      <!--     </execution> -->
+      <!--   </executions> -->
+      <!-- </plugin> -->
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.urbanairship</groupId>
   <artifactId>datacube</artifactId>
-  <version>1.5.0</version>
+  <version>1.5.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>datacube</name>

--- a/pom.xml
+++ b/pom.xml
@@ -1,12 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <parent>
-    <groupId>org.sonatype.oss</groupId>
-    <artifactId>oss-parent</artifactId>
-    <version>7</version>
-  </parent>
-
   <groupId>com.urbanairship</groupId>
   <artifactId>datacube</artifactId>
   <version>1.5.0</version>

--- a/pom.xml
+++ b/pom.xml
@@ -42,31 +42,7 @@
           </execution>
         </executions>
       </plugin>
-
-      <!-- This attaches a -javadoc.jar artifact to the build -->
-      <!-- <plugin> -->
-      <!--   <groupId>org.apache.maven.plugins</groupId> -->
-      <!--   <artifactId>maven&#45;javadoc&#45;plugin</artifactId> -->
-      <!--   <version>2.8.1</version> -->
-      <!--   <executions> -->
-      <!--     <execution> -->
-      <!--       <id>attach&#45;javadocs</id> -->
-      <!--       <goals> -->
-      <!--         <goal>jar</goal> -->
-      <!--       </goals> -->
-      <!--     </execution> -->
-      <!--   </executions> -->
-      <!-- </plugin> -->
-
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-release-plugin</artifactId>
-        <version>2.3.2</version>
-        <configuration>
-          <tagBase>git://github.com/urbanairship/datacube</tagBase>
-        </configuration>
-      </plugin>
-    </plugins>
+     </plugins>
   </build>
 
   <licenses>


### PR DESCRIPTION
- We don't render the javadocs anywhere, and they will cause build failures under new but not old jdks. 
- The maven release plugin no longer successfully publishes to oss sonatype, and we're in the process of automating that process via bintray anyway.