### PR TITLE
Does checkAndPut with null value when checking for absence

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.urbanairship</groupId>
   <artifactId>datacube</artifactId>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>2.0.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>datacube</name>

--- a/src/main/java/com/urbanairship/datacube/idservices/HBaseIdService.java
+++ b/src/main/java/com/urbanairship/datacube/idservices/HBaseIdService.java
@@ -50,7 +50,7 @@ public class HBaseIdService implements IdService {
     private enum Status {@Deprecated ALLOCATING, ALLOCATED} // don't change ordinals
 
     private static final byte[] ALLOCATED_BYTES = new byte[]{(byte) Status.ALLOCATED.ordinal()};
-    private static final byte[] EMPTY = new byte[0];
+    private static final byte[] NULL_BYTE_ARRAY = null;
 
     private final HTablePool pool;
     private final byte[] counterTable;
@@ -132,7 +132,7 @@ public class HBaseIdService implements IdService {
         byte[] allocatedRecord = ArrayUtils.addAll(HBaseIdService.ALLOCATED_BYTES, Util.longToBytes(id));
         put.add(cf, QUALIFIER, allocatedRecord);
 
-        boolean swapSuccess = WithHTable.checkAndPut(pool, lookupTable, lookupKey, cf, QUALIFIER, EMPTY, put);
+        boolean swapSuccess = WithHTable.checkAndPut(pool, lookupTable, lookupKey, cf, QUALIFIER, NULL_BYTE_ARRAY, put);
         if (swapSuccess) {
             timer.stop();
             return Util.leastSignificantBytes(id, numIdBytes);


### PR DESCRIPTION
When checking for absence of a cell in the `checkAndPut` operation we should be using a null byte array for the compare value instead of an empty byte array.

Per the hbase docs -> https://hbase.apache.org/1.2/apidocs/org/apache/hadoop/hbase/client/Table.html#checkAndPut(byte[],%20byte[],%20byte[],%20byte[],%20org.apache.hadoop.hbase.client.Put)

Based on testing using an empty byte array is also accepted by hbase, but BigTable is not as permissive causing a runtime exception when the `get` following an unsuccesful `checkAndPut` also fails.