### PR TITLE
Updates JmxReporter formatting

### DIFF
--- a/src/main/java/com/urbanairship/datacube/metrics/Metrics.java
+++ b/src/main/java/com/urbanairship/datacube/metrics/Metrics.java
@@ -42,6 +42,7 @@ public final class Metrics {
     private static final JmxReporter reporter = JmxReporter.forRegistry(registry)
             .convertDurationsTo(TimeUnit.MILLISECONDS)
             .convertRatesTo(TimeUnit.SECONDS)
+            .createsObjectNamesWith(new ObjectNameFactoryImpl())
             .build();
 
     static {

--- a/src/main/java/com/urbanairship/datacube/metrics/ObjectNameFactoryImpl.java
+++ b/src/main/java/com/urbanairship/datacube/metrics/ObjectNameFactoryImpl.java
@@ -1,0 +1,43 @@
+package com.urbanairship.datacube.metrics;
+
+import com.codahale.metrics.JmxReporter;
+import com.codahale.metrics.ObjectNameFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+
+
+public class ObjectNameFactoryImpl implements ObjectNameFactory {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(JmxReporter.class);
+
+    @Override
+    public ObjectName createName(String type, String domain, String name) {
+        try {
+            return new ObjectName(name);
+        } catch (MalformedObjectNameException e) {
+            try {
+                return new ObjectName(ObjectName.quote(name));
+            } catch (MalformedObjectNameException e1) {
+                try {
+                    // fall back to the Metrics 3 naming
+                    return createMetrics3Name(domain, name);
+                } catch (MalformedObjectNameException e2) {
+                    LOGGER.warn("Unable to register " + name, e2);
+                    throw new RuntimeException(e2);
+                }
+            }
+        }
+    }
+
+    // Default behavior of Metrics 3 library, for fallback
+    private ObjectName createMetrics3Name(String domain, String name) throws MalformedObjectNameException {
+        try {
+            return new ObjectName(domain, "name", name);
+        } catch (MalformedObjectNameException e) {
+            return new ObjectName(domain, "name", ObjectName.quote(name));
+        }
+    }
+}


### PR DESCRIPTION
Current formatted mbean `ObjectName` example:
* `com.codahale.metrics.JmxReporter$JmxMeter[metrics:name="com.urbanairship.datacube:type=DataCubeIo,scope=scope,name=backOffMeter"]`

New formatted mbean `ObjectName` example:
* `com.codahale.metrics.JmxReporter$JmxMeter[com.urbanairship.datacube:type=DataCubeIo,scope=scope,name=backOffMeter]`