### PR TITLE
Removes jvm metrics from registry

### DIFF
--- a/RELEASE_NOTES.txt
+++ b/RELEASE_NOTES.txt
@@ -1,3 +1,8 @@
+4.0.1
+=====
+Removes `bufferpool`, `garbagecollector`, and `memorypool` metrics from static `Metrics` registry.
+If clients would like these metrics to be reported on they can be added manually.
+
 4.0.0
 =====
 Modifies how JmxReporter does object naming.

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <groupId>com.urbanairship</groupId>
   <artifactId>datacube</artifactId>
-  <version>2.0.1-SNAPSHOT</version>
+  <version>4.0.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>datacube</name>

--- a/src/main/java/com/urbanairship/datacube/metrics/Metrics.java
+++ b/src/main/java/com/urbanairship/datacube/metrics/Metrics.java
@@ -9,11 +9,7 @@ import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Timer;
-import com.codahale.metrics.jvm.BufferPoolMetricSet;
-import com.codahale.metrics.jvm.GarbageCollectorMetricSet;
-import com.codahale.metrics.jvm.MemoryUsageGaugeSet;
 
-import java.lang.management.ManagementFactory;
 import java.util.SortedMap;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
@@ -46,10 +42,6 @@ public final class Metrics {
             .build();
 
     static {
-        // expose JVM stats to metrics registry
-        registry.register("bufferpool", new BufferPoolMetricSet(ManagementFactory.getPlatformMBeanServer()));
-        registry.register("garbagecollector", new GarbageCollectorMetricSet());
-        registry.register("memorypool", new MemoryUsageGaugeSet());
         reporter.start();
     }
 


### PR DESCRIPTION
Don't add jvm metrics to metrics registry. Clients can register these metrics manually if they would like them