### PR TITLE
interfaces and batch put

### DIFF
--- a/src/main/java/com/urbanairship/datacube/AsyncIncrementer.java
+++ b/src/main/java/com/urbanairship/datacube/AsyncIncrementer.java
@@ -1,0 +1,105 @@
+package com.urbanairship.datacube;
+
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.AbstractScheduledService;
+import com.urbanairship.datacube.dbharnesses.BatchDbHarness;
+import com.urbanairship.datacube.metrics.Metrics;
+import com.urbanairship.datacube.ops.LongOp;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+
+import java.io.IOException;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+
+
+/**
+ * converts bytes to maps of long ops, buffers until we have achieved the configured number of updates and then attempts
+ * to flush to the underlying database.
+ */
+public class AsyncIncrementer extends AbstractScheduledService implements Function<byte[], CompletableFuture<Void>> {
+    private final long maxAge;
+    private final DataCube<LongOp> dataCube;
+    private final Function<byte[], WriteBuilder> serializer;
+    private BatchDbHarness batchDbHarness;
+    private Function<ThreadsafeBatch.Update<?, ?>, BatchDbHarness.RetryPolicy> retryPolicyFactory;
+
+    private static final Logger log = LogManager.getLogger(AsyncIncrementer.class);
+
+    private final ThreadsafeBatch<LongOp> batch;
+
+    public AsyncIncrementer(long maxAge,
+                            int maxSize,
+                            DataCube<LongOp> dataCube,
+                            Function<byte[], WriteBuilder> serializer,
+                            BatchDbHarness batchDbHarness,
+                            Function<ThreadsafeBatch.Update<?, ?>, BatchDbHarness.RetryPolicy> retryPolicyFactory
+    ) {
+        this.maxAge = maxAge;
+        this.dataCube = dataCube;
+        this.serializer = serializer;
+        this.batchDbHarness = batchDbHarness;
+        this.retryPolicyFactory = retryPolicyFactory;
+        this.batch = new ThreadsafeBatch<LongOp>(maxAge, maxSize, (a, b) -> (LongOp) a.add(b));
+
+        Metrics.gauge(AsyncIncrementer.class, "events pending", batch::getPending);
+        Metrics.gauge(AsyncIncrementer.class, "events written", batch::getTotalUpdatesSeen);
+        Metrics.gauge(AsyncIncrementer.class, "rows written", batch::getRowWrites);
+        Metrics.gauge(AsyncIncrementer.class, "rows seen", batch::getRowsSeen);
+    }
+
+    public CompletableFuture<Void> apply(byte[] event) {
+        try {
+            WriteBuilder writes = serializer.apply(event);
+            Batch<LongOp> batch = dataCube.getWrites(writes, new LongOp(1));
+            return addBatch(batch);
+        } catch (InterruptedException | IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+
+    private CompletableFuture<Void> addBatch(Batch<LongOp> batch) throws InterruptedException, IOException {
+        // it could have filled up in the meantime.
+        Preconditions.checkState(isRunning(), "service must be running to add a batch to it");
+        while (isRunning()) {
+            if (Thread.currentThread().isInterrupted()) {
+                throw new InterruptedException();
+            }
+
+            Optional<CompletableFuture<Void>> future = this.batch.offer(batch.getMap());
+            if (future.isPresent()) {
+                return future.get();
+            }
+            flush();
+            // then try again.
+        }
+        // it will never complete.
+        return new CompletableFuture<>();
+    }
+
+    private void flush() throws InterruptedException, IOException {
+        Optional<ThreadsafeBatch.Update<Address, LongOp>> maybeUpdate = this.batch.drain();
+        if (maybeUpdate.isPresent()) {
+            ThreadsafeBatch.Update<Address, LongOp> update = maybeUpdate.get();
+            batchDbHarness.increment(update.getMap(), retryPolicyFactory.apply(update));
+        }
+    }
+
+    @Override
+    protected void runOneIteration() throws InterruptedException, IOException {
+        if (this.batch.isFull()) flush();
+    }
+
+    @Override
+    protected Scheduler scheduler() {
+        return Scheduler.newFixedDelaySchedule(maxAge, maxAge, TimeUnit.MILLISECONDS);
+    }
+
+    @Override
+    protected void shutDown() throws InterruptedException, IOException {
+        while (!batch.isEmpty()) flush();
+    }
+}

--- a/src/main/java/com/urbanairship/datacube/DataCubeIo.java
+++ b/src/main/java/com/urbanairship/datacube/DataCubeIo.java
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.LinkedBlockingQueue;

--- a/src/main/java/com/urbanairship/datacube/DbHarness.java
+++ b/src/main/java/com/urbanairship/datacube/DbHarness.java
@@ -74,7 +74,7 @@ public interface DbHarness<T extends Op> {
     enum CommitType {
         READ_COMBINE_CAS,
         INCREMENT,
-        OVERWRITE
+        BATCH_INCREMENT, OVERWRITE
     }
 
     /**

--- a/src/main/java/com/urbanairship/datacube/ThreadsafeBatch.java
+++ b/src/main/java/com/urbanairship/datacube/ThreadsafeBatch.java
@@ -135,7 +135,7 @@ public class ThreadsafeBatch<T> {
     }
 
 
-    public synchronized boolean isFull() {
+    public boolean isFull() {
         // the first one is oldest.
         return getPending() > maxSize || (updates.peek() != null && System.currentTimeMillis() - updates.peek().birthday > maxAge);
     }

--- a/src/main/java/com/urbanairship/datacube/ThreadsafeBatch.java
+++ b/src/main/java/com/urbanairship/datacube/ThreadsafeBatch.java
@@ -1,0 +1,195 @@
+package com.urbanairship.datacube;
+
+import com.google.common.base.Objects;
+import com.google.common.collect.ImmutableMap;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BinaryOperator;
+
+/**
+ * Multiple threads can put against or drain the batch at once.
+ *
+ * @param <T>
+ */
+public class ThreadsafeBatch<T> {
+    private final BlockingQueue<Update<Address, T>> updates;
+    private final BinaryOperator<T> binaryOperator;
+
+    private final long maxAge;
+    private final int maxSize;
+
+    private final AtomicLong drained = new AtomicLong();
+    private final AtomicLong totalUpdatesSeen = new AtomicLong();
+
+    private final AtomicLong rowsUpdated = new AtomicLong();
+    private final AtomicLong rowsSeen = new AtomicLong();
+
+    /**
+     * @param maxAge         The maximum age before we will reports "full" to clients who ask
+     * @param maxSize        The maximum number of batches before we block waiting flush, and maximum number of elements
+     *                       we
+     *                       will pull out of the queue when we flush.
+     * @param binaryOperator
+     */
+    public ThreadsafeBatch(long maxAge, int maxSize, BinaryOperator<T> binaryOperator) {
+        this.maxAge = maxAge;
+        this.maxSize = maxSize;
+        this.binaryOperator = binaryOperator;
+        this.updates = new LinkedBlockingQueue<Update<Address, T>>(maxSize);
+    }
+
+    public Optional<CompletableFuture<Void>> offer(Map<Address, T> other) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        boolean offer = updates.offer(new Update<>(other, System.currentTimeMillis(), future));
+        if (!offer) {
+            return Optional.empty();
+        }
+        mark(other);
+        return Optional.of(future);
+    }
+
+    public CompletableFuture<Void> put(Map<Address, T> other) throws InterruptedException {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        updates.put(new Update<>(other, System.currentTimeMillis(), future));
+        mark(other);
+        return future;
+    }
+
+    private void mark(Map<Address, T> other) {
+        totalUpdatesSeen.incrementAndGet();
+        rowsSeen.addAndGet(other.size());
+    }
+
+    public long getPending() {
+        return Math.max(totalUpdatesSeen.get() - drained.get(), updates.size());
+    }
+
+    public long getTotalUpdatesSeen() {
+        return totalUpdatesSeen.get();
+    }
+
+    public long getRowWrites() {
+        return rowsUpdated.get();
+    }
+
+    public long getRowsSeen() {
+        return rowsSeen.get();
+    }
+
+    public Optional<Update<Address, T>> drain() {
+        Optional<Update<Address, T>> update = condense(updates, binaryOperator, maxSize, drained);
+        update.ifPresent(u -> rowsUpdated.addAndGet(u.getMap().size()));
+        return update;
+    }
+
+    /**
+     * Compact the list of updates to a single updates, resolving cell collisions with {@param binaryOperator}
+     *
+     * @param updates        A queue of updates that supports concurrent access
+     * @param binaryOperator Applied to values elements to resolve key collisions
+     * @param maxSize        The maximum number of udpates we'll consider
+     * @param drained        We'll increment this with the number of elements we drained
+     * @param <K>            The key type of the Update's internal map.
+     * @param <V>            The value type of the Updates internal map
+     *
+     * @return present if there were any updates to condense, absent otherwise. A single update whose internal map
+     * represents all the update operations condensed.
+     */
+    public static <K, V> Optional<Update<K, V>> condense(BlockingQueue<Update<K, V>> updates, BinaryOperator<V> binaryOperator, int maxSize, AtomicLong drained) {
+        Update<K, V> first = updates.poll();
+        if (first != null) {
+            Collection<Update<K, V>> list = new ArrayList<>();
+            list.add(first);
+            updates.drainTo(list, maxSize - 1);
+            drained.addAndGet(list.size());
+            return Optional.of(condense(binaryOperator, list));
+        }
+        return Optional.empty();
+    }
+
+    private static <K, V> Update<K, V> condense(BinaryOperator<V> binaryOperator, Collection<Update<K, V>> list) {
+        HashMap<K, V> builder = new HashMap<>();
+        long oldestEventBirthday = 0;
+        List<CompletableFuture<Void>> futures = new ArrayList<>();
+        for (Update<K, V> update : list) {
+            oldestEventBirthday = Math.min(oldestEventBirthday, update.birthday);
+            futures.add(update.future);
+            for (Map.Entry<K, V> entry : update.map.entrySet()) {
+                builder.merge(entry.getKey(), entry.getValue(), binaryOperator);
+            }
+        }
+        return new Update<K, V>(ImmutableMap.copyOf(builder), oldestEventBirthday, CompletableFuture.allOf(futures.toArray(new CompletableFuture[futures.size()])));
+    }
+
+    public boolean isEmpty() {
+        return updates.isEmpty();
+    }
+
+
+    public synchronized boolean isFull() {
+        // the first one is oldest.
+        return getPending() > maxSize || (updates.peek() != null && System.currentTimeMillis() - updates.peek().birthday > maxAge);
+    }
+
+    @Override
+    public String toString() {
+        return Objects.toStringHelper(this)
+                .add("updates", updates)
+                .add("maxAge", maxAge)
+                .add("maxSize", maxSize)
+                .toString();
+    }
+
+    public static class Update<K, T> implements Comparable<Update<?, ?>> {
+        public final CompletableFuture<Void> future;
+        public Map<K, T> map;
+        public long birthday;
+
+        public Update(Map<K, T> map, long birthday, CompletableFuture<Void> future) {
+            this.map = map;
+            this.birthday = birthday;
+            this.future = future;
+        }
+
+        public CompletableFuture<Void> getFuture() {
+            return future;
+        }
+
+        public Map<K, T> getMap() {
+            return map;
+        }
+
+        public long getBirthday() {
+            return birthday;
+        }
+
+        @Override
+        public int compareTo(Update o) {
+            return Long.compare(this.birthday, o.birthday);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof Update)) return false;
+            Update<?, ?> update = (Update<?, ?>) o;
+            return birthday == update.birthday &&
+                    Objects.equal(future, update.future) &&
+                    Objects.equal(map, update.map);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hashCode(future, map, birthday);
+        }
+    }
+}

--- a/src/main/java/com/urbanairship/datacube/WriteBuilder.java
+++ b/src/main/java/com/urbanairship/datacube/WriteBuilder.java
@@ -5,11 +5,14 @@ Copyright 2012 Urban Airship and Contributors
 package com.urbanairship.datacube;
 
 import com.google.common.collect.HashMultimap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.SetMultimap;
 
 import java.util.Map;
+import java.util.Set;
 
 public class WriteBuilder {
     private final Map<Dimension<?>, SetMultimap<BucketType, byte[]>> buckets;

--- a/src/main/java/com/urbanairship/datacube/dbharnesses/BatchDbHarness.java
+++ b/src/main/java/com/urbanairship/datacube/dbharnesses/BatchDbHarness.java
@@ -1,0 +1,53 @@
+package com.urbanairship.datacube.dbharnesses;
+
+import com.urbanairship.datacube.Address;
+import com.urbanairship.datacube.ops.LongOp;
+
+import java.io.IOException;
+import java.util.Map;
+
+
+/**
+ * Synchronously executes the operations with the minimum number of database requests possible.
+ */
+public interface BatchDbHarness {
+    /**
+     * Issue a single request incrementing every provided row in the operation.
+     *
+     * @param batch   A map from Address to increment operations, defining all the updates you'd like to accomplish
+     * @param sleeper Defines how you'd like to address write failures, either due to IOExceptions submitting the
+     *                whole batch to the underlying data store, or due to failure to increment a given row.
+     *
+     *                The method can still throw an IOException due to failure to retrieve the mapped id from the
+     *                underlying data store
+     *
+     * @return Assuming normal completion, any entries which were not written to the database even after retry are
+     * returned here.
+     *
+     * @throws IOException          We had an error talking to the underlying database. Some of the batch operations may
+     *                              have executed, depending on the guarantees of the underlying database.
+     * @throws InterruptedException We had an error talking to the underlying database. Some of the batch operations may
+     *                              have executed, depending on the guarantees of the underlying database.
+     */
+    void increment(Map<Address, LongOp> batch, RetryPolicy sleeper) throws InterruptedException, IOException;
+
+
+    interface RetryPolicy {
+        /**
+         * blocks until an appropriate duration has elapsed
+         *
+         * @param attempt the try number for which we should sleep. A constant or random jittered retry policy would
+         *                ignore this parameter. An exponential backoff would wait {@code Math.pow(base_period,
+         *                attempt)} before the next attempt, &c.
+         *
+         * @return false if we have exhausted our retries, true otherwise.
+         *
+         * @throws InterruptedException
+         */
+        boolean sleep(int attempt) throws InterruptedException;
+    }
+
+    interface BlockingIO<V, R> {
+        R apply(V v) throws IOException, InterruptedException;
+    }
+}

--- a/src/main/java/com/urbanairship/datacube/dbharnesses/BatchDbHarness.java
+++ b/src/main/java/com/urbanairship/datacube/dbharnesses/BatchDbHarness.java
@@ -15,7 +15,7 @@ public interface BatchDbHarness {
      * Issue a single request incrementing every provided row in the operation.
      *
      * @param batch   A map from Address to increment operations, defining all the updates you'd like to accomplish
-     * @param sleeper Defines how you'd like to address write failures, either due to IOExceptions submitting the
+     * @param retryPolicy Defines how you'd like to address write failures, either due to IOExceptions submitting the
      *                whole batch to the underlying data store, or due to failure to increment a given row.
      *
      *                The method can still throw an IOException due to failure to retrieve the mapped id from the
@@ -29,7 +29,7 @@ public interface BatchDbHarness {
      * @throws InterruptedException We had an error talking to the underlying database. Some of the batch operations may
      *                              have executed, depending on the guarantees of the underlying database.
      */
-    void increment(Map<Address, LongOp> batch, RetryPolicy sleeper) throws InterruptedException, IOException;
+    void increment(Map<Address, LongOp> batch, RetryPolicy retryPolicy) throws InterruptedException, IOException;
 
 
     interface RetryPolicy {

--- a/src/main/java/com/urbanairship/datacube/dbharnesses/BatchDbHarness.java
+++ b/src/main/java/com/urbanairship/datacube/dbharnesses/BatchDbHarness.java
@@ -7,9 +7,6 @@ import java.io.IOException;
 import java.util.Map;
 
 
-/**
- * Synchronously executes the operations with the minimum number of database requests possible.
- */
 public interface BatchDbHarness {
     /**
      * Issue a single request incrementing every provided row in the operation.

--- a/src/main/java/com/urbanairship/datacube/dbharnesses/BatchDbHarness.java
+++ b/src/main/java/com/urbanairship/datacube/dbharnesses/BatchDbHarness.java
@@ -40,7 +40,7 @@ public interface BatchDbHarness {
          *                ignore this parameter. An exponential backoff would wait {@code Math.pow(base_period,
          *                attempt)} before the next attempt, &c.
          *
-         * @return false if we have exhausted our retries, true otherwise.
+         * @return {@code true} if we have exhausted our retries, {@code false} otherwise.
          *
          * @throws InterruptedException
          */

--- a/src/main/java/com/urbanairship/datacube/dbharnesses/HBaseDbHarness.java
+++ b/src/main/java/com/urbanairship/datacube/dbharnesses/HBaseDbHarness.java
@@ -36,6 +36,7 @@ import javax.annotation.Nullable;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -326,40 +327,65 @@ public class HBaseDbHarness<T extends Op> implements DbHarness<T> {
 
         long nanoTimeBeforeBatch = System.nanoTime();
 
+
         try {
-            for (Map.Entry<Address, T> entry : batchMap.entrySet()) {
-                final Address address = entry.getKey();
-                final T op = entry.getValue();
-                final byte[] rowKey = ArrayUtils.addAll(uniqueCubeName, address.toWriteKey(idService));
-                final long nanoTimeBeforeWrite = System.nanoTime();
-
-                byte[] dbBytes;
-                switch (commitType) {
-                    case INCREMENT:
-                        long postIncr = increment(rowKey, op);
-                        dbBytes = Bytes.toBytes(postIncr);
-                        break;
-                    case READ_COMBINE_CAS:
-                        dbBytes = readCombineCas(rowKey, op);
-                        break;
-                    case OVERWRITE:
-                        overwrite(rowKey, op);
-                        dbBytes = op.serialize();
-                        break;
-                    default:
-                        throw new RuntimeException("Unsupported commit type " + commitType);
+            if (commitType.equals(CommitType.BATCH_INCREMENT)) {
+                HbaseBatchIncrementer hbaseBatchIncrementer = new HbaseBatchIncrementer(cf, metricsScope, pool, tableName);
+                Map<byte[], Long> rows = new HashMap<>();
+                Map<byte[], Address> backwards = new HashMap<>();
+                for (Map.Entry<Address, T> entry : batchMap.entrySet()) {
+                    final Address address = entry.getKey();
+                    final T op = entry.getValue();
+                    final byte[] rowKey = ArrayUtils.addAll(uniqueCubeName, address.toWriteKey(idService));
+                    byte[] serialize = op.serialize();
+                    long value = Bytes.toLong(serialize);
+                    rows.put(rowKey, value);
+                    backwards.put(rowKey, address);
+                    successfulRows.put(rowKey, serialize);
                 }
 
-                long writeDurationNanos = System.nanoTime() - nanoTimeBeforeWrite;
-                singleWriteTimer.update(writeDurationNanos, TimeUnit.NANOSECONDS);
-
-                if (log.isDebugEnabled()) {
-                    log.debug("Succesfully wrote cube:" + Arrays.toString(uniqueCubeName) +
-                            " address:" + address);
+                Map<byte[], Long> failures = hbaseBatchIncrementer.apply(rows);
+                for (Map.Entry<byte[], Long> entry : failures.entrySet()) {
+                    successfulRows.remove(entry.getKey());
                 }
-                successfulAddresses.add(address);
-                successfulRows.put(rowKey, dbBytes);
-            }
+
+                for (Map.Entry<byte[], byte[]> entry : successfulRows.entrySet()) {
+                    successfulAddresses.add(backwards.get(entry.getKey()));
+                }
+            } else
+                for (Map.Entry<Address, T> entry : batchMap.entrySet()) {
+                    final Address address = entry.getKey();
+                    final T op = entry.getValue();
+                    final byte[] rowKey = ArrayUtils.addAll(uniqueCubeName, address.toWriteKey(idService));
+                    final long nanoTimeBeforeWrite = System.nanoTime();
+
+                    byte[] dbBytes;
+                    switch (commitType) {
+                        case INCREMENT:
+                            long postIncr = increment(rowKey, op);
+                            dbBytes = Bytes.toBytes(postIncr);
+                            break;
+                        case READ_COMBINE_CAS:
+                            dbBytes = readCombineCas(rowKey, op);
+                            break;
+                        case OVERWRITE:
+                            overwrite(rowKey, op);
+                            dbBytes = op.serialize();
+                            break;
+                        default:
+                            throw new RuntimeException("Unsupported commit type " + commitType);
+                    }
+
+                    long writeDurationNanos = System.nanoTime() - nanoTimeBeforeWrite;
+                    singleWriteTimer.update(writeDurationNanos, TimeUnit.NANOSECONDS);
+
+                    if (log.isDebugEnabled()) {
+                        log.debug("Succesfully wrote cube:" + Arrays.toString(uniqueCubeName) +
+                                " address:" + address);
+                    }
+                    successfulAddresses.add(address);
+                    successfulRows.put(rowKey, dbBytes);
+                }
 
             long batchDurationNanos = System.nanoTime() - nanoTimeBeforeBatch;
             flushSuccessTimer.update(batchDurationNanos, TimeUnit.NANOSECONDS);

--- a/src/main/java/com/urbanairship/datacube/dbharnesses/HbaseBatchDbHarness.java
+++ b/src/main/java/com/urbanairship/datacube/dbharnesses/HbaseBatchDbHarness.java
@@ -1,0 +1,131 @@
+package com.urbanairship.datacube.dbharnesses;
+
+import com.codahale.metrics.Histogram;
+import com.google.common.collect.ImmutableMap;
+import com.urbanairship.datacube.Address;
+import com.urbanairship.datacube.IdService;
+import com.urbanairship.datacube.metrics.Metrics;
+import com.urbanairship.datacube.ops.LongOp;
+import org.apache.commons.lang.ArrayUtils;
+import org.apache.hadoop.hbase.client.HTablePool;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.slf4j.MDC;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+public class HbaseBatchDbHarness implements BatchDbHarness {
+    private final byte[] uniqueCubeName;
+
+    private final IdService idService;
+    private final BiConsumer<Map<Address, LongOp>, IOException> idLookupFailureConsumer;
+    private final BiConsumer<Map<byte[], Long>, IOException> incrementFailure;
+
+    private final Histogram attempts;
+    private final Histogram failedIncrementOperations;
+    private final Histogram ioexceptions;
+    private BlockingIO<Map<byte[], Long>, Map<byte[], Long>> incrementer;
+
+    public static HbaseBatchDbHarness create(
+            byte[] uniqueCubeName,
+            byte[] tableName,
+            byte[] cf,
+            String metricsScope,
+            IdService idService,
+            HTablePool pool
+    ) {
+        return new HbaseBatchDbHarness(
+                metricsScope,
+                uniqueCubeName,
+                new HbaseBatchIncrementer(cf, metricsScope, pool, tableName),
+                idService,
+                (map, ioe) -> log.error("Failed lookup for " + map + " after retries", ioe),
+                (map, ioe) -> log.error("Failed lookup for increment " + map + " after retries", ioe)
+        );
+    }
+
+    public HbaseBatchDbHarness(String metricName, byte[] uniqueCubeName, BlockingIO<Map<byte[], Long>, Map<byte[], Long>> incrementer, IdService idService, BiConsumer<Map<Address, LongOp>, IOException> idLookupFailureConsumer, BiConsumer<Map<byte[], Long>, IOException> incrementFailure) {
+        this.uniqueCubeName = uniqueCubeName;
+        this.idService = idService;
+        this.incrementer = incrementer;
+        this.idLookupFailureConsumer = idLookupFailureConsumer;
+        this.incrementFailure = incrementFailure;
+
+        attempts = Metrics.histogram(BatchDbHarness.class, "attempts", metricName);
+        failedIncrementOperations = Metrics.histogram(BatchDbHarness.class, "failedIncrementOperations", metricName);
+        ioexceptions = Metrics.histogram(BatchDbHarness.class, "IOException", metricName);
+    }
+
+    private static final Logger log = LogManager.getLogger(HbaseBatchDbHarness.class);
+
+    private <V, R> R retryIo(RetryPolicy retryPolicy, BlockingIO<V, R> io, V input, int hash) throws IOException, InterruptedException {
+        int failures = 0;
+        boolean retriesExhausted = false;
+        while (!retriesExhausted) {
+            try {
+                return io.apply(input);
+            } catch (IOException exception) {
+                failures++;
+                retriesExhausted = retryPolicy.sleep(failures);
+                log.error(String.format("idlookup attempts %s for batch with hashcode %s failed", exception, hash));
+            } finally {
+                ioexceptions.update(failures);
+            }
+        }
+        throw new IOException("io operation retries exhausted before success for " + hash);
+    }
+
+    @Override
+    public void increment(Map<Address, LongOp> batch, RetryPolicy retryPolicy) throws InterruptedException, IOException {
+        int hash = batch.hashCode();
+        MDC.put("batch", String.valueOf(hash));
+
+        Map<byte[], Long> writes = new HashMap<>();
+        for (Map.Entry<Address, LongOp> entry : batch.entrySet()) {
+            try {
+                byte[] rowKey = this.retryIo(retryPolicy, this::addressToRowKey, entry.getKey(), hash);
+                long increment = entry.getValue().getLong();
+                writes.put(rowKey, increment);
+            } catch (IOException ioe) {
+                idLookupFailureConsumer.accept(ImmutableMap.<Address, LongOp>builder().put(entry).build(), ioe);
+            }
+        }
+
+        int attempts = 0;
+        boolean retriesExhausted = false;
+
+        while (!retriesExhausted) {
+            if (writes.isEmpty()) {
+                return;
+            }
+            try {
+                writes = this.retryIo(retryPolicy, incrementer, writes, hash);
+                if (writes.isEmpty()) {
+                    break;
+                }
+                failedIncrementOperations.update(writes.size());
+                attempts++;
+                retriesExhausted = retryPolicy.sleep(attempts);
+            } catch (IOException ioe) {
+                incrementFailure.accept(writes, ioe);
+                break;
+            }
+        }
+
+        if (!writes.isEmpty()) {
+            incrementFailure.accept(writes, null);
+        }
+
+        this.attempts.update(attempts);
+        MDC.clear();
+    }
+
+    private byte[] addressToRowKey(Address a) throws IOException, InterruptedException {
+        return ArrayUtils.addAll(uniqueCubeName, a.toWriteKey(idService));
+    }
+
+}
+

--- a/src/main/java/com/urbanairship/datacube/dbharnesses/HbaseBatchIncrementer.java
+++ b/src/main/java/com/urbanairship/datacube/dbharnesses/HbaseBatchIncrementer.java
@@ -1,0 +1,59 @@
+package com.urbanairship.datacube.dbharnesses;
+
+import com.codahale.metrics.Histogram;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.urbanairship.datacube.metrics.Metrics;
+import org.apache.hadoop.hbase.client.HTablePool;
+import org.apache.hadoop.hbase.client.Increment;
+import org.apache.hadoop.hbase.client.Row;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static com.urbanairship.datacube.dbharnesses.HBaseDbHarness.QUALIFIER;
+
+public class HbaseBatchIncrementer implements BatchDbHarness.BlockingIO<Map<byte[], Long>, Map<byte[], Long>> {
+    private final byte[] cf;
+    private final Histogram incrementSize;
+    private final HTablePool pool;
+    private final byte[] tableName;
+
+    public HbaseBatchIncrementer(byte[] cf, String metricsScope, HTablePool pool, byte[] tableName) {
+        this.cf = cf;
+        this.incrementSize = Metrics.histogram(BatchDbHarness.class, "incrementSize", metricsScope);
+        this.pool = pool;
+        this.tableName = tableName;
+
+    }
+
+    @Override
+    public Map<byte[], Long> apply(Map<byte[], Long> writes) throws IOException, InterruptedException {
+        ImmutableMap.Builder<byte[], Long> failures = ImmutableMap.builder();
+
+        List<Row> increments = new ArrayList<>();
+
+        List<Map.Entry<byte[], Long>> entries = ImmutableList.copyOf(writes.entrySet());
+
+        for (Map.Entry<byte[], Long> entry : entries) {
+            // .... this is what the `increment` method below does. It doesn't seem super safe to me.
+            long amount = entry.getValue();
+            Increment increment = new Increment(entry.getKey());
+            increment.addColumn(cf, QUALIFIER, amount);
+            incrementSize.update(amount);
+            increments.add(increment);
+        }
+
+        Object[] objects = WithHTable.batch(pool, tableName, increments);
+
+        for (int i = 0; i < objects.length; ++i) {
+            if (objects[i] == null) {
+                failures.put(entries.get(i));
+            }
+        }
+
+        return failures.build();
+    }
+}

--- a/src/main/java/com/urbanairship/datacube/dbharnesses/HbaseBatchIncrementer.java
+++ b/src/main/java/com/urbanairship/datacube/dbharnesses/HbaseBatchIncrementer.java
@@ -38,7 +38,6 @@ public class HbaseBatchIncrementer implements BatchDbHarness.BlockingIO<Map<byte
         List<Map.Entry<byte[], Long>> entries = ImmutableList.copyOf(writes.entrySet());
 
         for (Map.Entry<byte[], Long> entry : entries) {
-            // .... this is what the `increment` method below does. It doesn't seem super safe to me.
             long amount = entry.getValue();
             Increment increment = new Increment(entry.getKey());
             increment.addColumn(cf, QUALIFIER, amount);

--- a/src/main/java/com/urbanairship/datacube/dbharnesses/ParallelBatchDbHarness.java
+++ b/src/main/java/com/urbanairship/datacube/dbharnesses/ParallelBatchDbHarness.java
@@ -1,0 +1,89 @@
+package com.urbanairship.datacube.dbharnesses;
+
+import com.google.common.collect.Iterables;
+import com.google.common.util.concurrent.AbstractIdleService;
+import com.urbanairship.datacube.Address;
+import com.urbanairship.datacube.NamedThreadFactory;
+import com.urbanairship.datacube.ops.LongOp;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+public class ParallelBatchDbHarness extends AbstractIdleService implements BatchDbHarness {
+    final BatchDbHarness delegate;
+    private final int threads;
+    private final int batchSize;
+    private String name;
+    private long terminationSeconds;
+
+    private Semaphore semaphore;
+    private Consumer<Map<byte[], Long>> failureConsumer;
+    private ExecutorService workers;
+
+    public ParallelBatchDbHarness(BatchDbHarness delegate, int threads, int batchSize, String name, long terminationSeconds, Consumer<Map<byte[], Long>> failureConsumer) {
+        this.delegate = delegate;
+        this.threads = threads;
+        this.batchSize = batchSize;
+        this.name = name;
+        this.terminationSeconds = terminationSeconds;
+        this.semaphore = new Semaphore(threads);
+        this.failureConsumer = failureConsumer;
+    }
+
+    @Override
+    public void increment(Map<Address, LongOp> batch, RetryPolicy retryPolicy) throws InterruptedException, IOException {
+        Set<Map.Entry<Address, LongOp>> entries = batch.entrySet();
+        Iterable<List<Map.Entry<Address, LongOp>>> partition = Iterables.partition(entries, batchSize);
+
+        for (List<Map.Entry<Address, LongOp>> entryList : partition) {
+            Map<Address, LongOp> map = entryList.stream().collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+
+            semaphore.acquire();
+            Incrementer incrementerRunnable = new Incrementer(map, retryPolicy);
+            CompletableFuture<Void> completableFuture = CompletableFuture.runAsync(incrementerRunnable, workers);
+            completableFuture.whenComplete((avoid, throwable) -> {
+                semaphore.release();
+            });
+        }
+
+    }
+
+    private final class Incrementer implements Runnable {
+        private final Map<Address, LongOp> batch;
+        private final RetryPolicy retryPolicy;
+
+        public Incrementer(Map<Address, LongOp> batch, RetryPolicy retryPolicy) {
+            this.batch = batch;
+            this.retryPolicy = retryPolicy;
+        }
+
+        @Override
+        public void run() {
+            try {
+                delegate.increment(batch, retryPolicy);
+            } catch (InterruptedException | IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
+
+    @Override
+    protected void startUp() throws Exception {
+        workers = Executors.newFixedThreadPool(threads, new NamedThreadFactory(name + " parallel db harness %d"));
+    }
+
+    @Override
+    protected void shutDown() throws Exception {
+        workers.shutdown();
+        workers.awaitTermination(terminationSeconds, TimeUnit.MILLISECONDS);
+    }
+}

--- a/src/main/java/com/urbanairship/datacube/ops/LongOp.java
+++ b/src/main/java/com/urbanairship/datacube/ops/LongOp.java
@@ -10,6 +10,8 @@ import com.urbanairship.datacube.Util;
 
 /**
  * Cube oplog mutation type for storing a long counter.
+ *
+ * Basically our custom impl of {@link java.util.concurrent.atomic.LongAdder}
  */
 public class LongOp implements Op {
     private final long val;

--- a/src/test/java/com/urbanairship/datacube/ThreadsafeBatchTest.java
+++ b/src/test/java/com/urbanairship/datacube/ThreadsafeBatchTest.java
@@ -1,0 +1,190 @@
+package com.urbanairship.datacube;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.primitives.Ints;
+import com.urbanairship.datacube.ops.LongOp;
+import org.junit.Test;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+
+public class ThreadsafeBatchTest {
+    @org.junit.Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void testQueToBatch() throws Exception {
+        LinkedBlockingQueue<ThreadsafeBatch.Update<Long, Long>> updates = new LinkedBlockingQueue<>();
+
+        updates.add(new ThreadsafeBatch.Update<>(ImmutableMap.of(1L, 1L), System.currentTimeMillis(), new CompletableFuture<>()));
+        updates.add(new ThreadsafeBatch.Update<>(ImmutableMap.of(1L, 1L), System.currentTimeMillis(), new CompletableFuture<>()));
+        updates.add(new ThreadsafeBatch.Update<>(ImmutableMap.of(3L, 2L), System.currentTimeMillis(), new CompletableFuture<>()));
+
+        updates.add(new ThreadsafeBatch.Update<>(ImmutableMap.of(1L, 1L), System.currentTimeMillis(), new CompletableFuture<>()));
+        updates.add(new ThreadsafeBatch.Update<>(ImmutableMap.of(5L, 2L), System.currentTimeMillis(), new CompletableFuture<>()));
+        updates.add(new ThreadsafeBatch.Update<>(ImmutableMap.of(1L, 2L, 9L, 2L, 4L, 1L), System.currentTimeMillis(), new CompletableFuture<>()));
+
+        AtomicLong drained = new AtomicLong();
+
+        ThreadsafeBatch.Update<Long, Long> firstBatch = ThreadsafeBatch.<Long, Long>condense(updates, Long::sum, 3, drained).get();
+
+        assertEquals(2, firstBatch.getMap().size());
+        assertEquals(firstBatch.getMap().get(1L).longValue(), 2L);
+        assertEquals(firstBatch.getMap().get(3L).longValue(), 2L);
+
+        Map<Long, Long> secondBatch = ThreadsafeBatch.<Long, Long>condense(updates, Long::sum, 3, drained).get().getMap();
+        assertEquals(secondBatch.size(), 4);
+        assertEquals(secondBatch.get(1L).longValue(), 3L);
+        assertEquals(secondBatch.get(5L).longValue(), 2L);
+        assertEquals(secondBatch.get(4L).longValue(), 1L);
+        assertEquals(secondBatch.get(9L).longValue(), 2L);
+        assertTrue(updates.isEmpty());
+
+        assertEquals(drained.get(), 6);
+
+        assertFalse(ThreadsafeBatch.<Long, Long>condense(updates, Long::sum, 2, drained).isPresent());
+    }
+
+    @org.junit.Test
+    public void test() throws Exception {
+
+        ExecutorService threads = Executors.newFixedThreadPool(100);
+
+        Bucketer<CSerializable> bucketer = new Bucketer.IdentityBucketer();
+
+        Dimension dimension = new Dimension<CSerializable>("dim", bucketer, false, Long.BYTES);
+
+        DataCube<LongOp> cube = new DataCube<LongOp>(ImmutableList.<Dimension<?>>of(dimension), ImmutableList.<Rollup>of(new Rollup(dimension)));
+
+        ThreadsafeBatch<LongOp> batch = new ThreadsafeBatch<LongOp>(1000, 90, (a, b) -> new LongOp(a.getLong() + b.getLong()));
+
+        ConcurrentHashMap<Address, Long> expected = new ConcurrentHashMap<>();
+
+        int each = 10;
+        int parallelism = 10;
+
+        AtomicInteger expectedCount = new AtomicInteger(5 * parallelism * each);
+
+
+        Address one = address(dimension, cube, 1);
+        Address two = address(dimension, cube, 2);
+        Address three = address(dimension, cube, 3);
+        Address four = address(dimension, cube, 4);
+        Address five = address(dimension, cube, 5);
+
+        expected.put(one, (long) parallelism * each * 5);
+        expected.put(two, (long) parallelism * each * 4);
+        expected.put(three, (long) parallelism * each * 3);
+        expected.put(four, (long) parallelism * each * 2);
+        expected.put(five, (long) parallelism * each * 1);
+
+
+        CompletableFuture producers = new CompletableFuture();
+        producers.complete(null);
+        for (int i = 0; i < parallelism; ++i) {
+            producers = CompletableFuture.allOf(
+                    producers,
+                    CompletableFuture.supplyAsync(new Adder(each, batch, one), threads),
+                    CompletableFuture.supplyAsync(new Adder(each, batch, one, two), threads),
+                    CompletableFuture.supplyAsync(new Adder(each, batch, one, two, three), threads),
+                    CompletableFuture.supplyAsync(new Adder(each, batch, one, two, three, four), threads),
+                    CompletableFuture.supplyAsync(new Adder(each, batch, one, two, three, four, five), threads)
+            );
+        }
+
+        threads.shutdown();
+
+        ImmutableMap.Builder<Address, Long> builder = ImmutableMap.<Address, Long>builder();
+        LinkedBlockingQueue<ThreadsafeBatch.Update<Address, LongOp>> queue = new LinkedBlockingQueue<>();
+
+        AtomicBoolean keepGoing = new AtomicBoolean(true);
+
+        CompletableFuture<Void> consumers = new CompletableFuture<Void>();
+        consumers.complete(null);
+        for (int i = 0; i < parallelism; ++i) {
+            CompletableFuture.allOf(
+                    consumers,
+                    CompletableFuture.runAsync(() -> {
+                        while (keepGoing.get() || !batch.isEmpty()) {
+                            try {
+                                Thread.sleep(100);
+                                queue.put(batch.drain().get());
+                            } catch (InterruptedException e) {
+                                throw new RuntimeException(e);
+                            }
+                        }
+                    })
+            );
+        }
+
+        producers.thenRun(() -> keepGoing.set(false));
+
+        producers.join();
+        consumers.join();
+
+        queue.put(batch.drain().get());
+        ThreadsafeBatch.condense(queue, (a, b) -> (LongOp) a.add(b), expectedCount.get(), new AtomicLong())
+                .get()
+                .getMap().forEach((key, value) -> builder.put(key, value.getLong()));
+
+
+        assertEquals(0, batch.getPending());
+        assertEquals(expectedCount.get(), batch.getTotalUpdatesSeen());
+
+        assertEquals(batch.toString(), ImmutableSet.copyOf(expected.entrySet()), ImmutableSet.copyOf(builder.build().entrySet()));
+    }
+
+    private Address address(Dimension dimension, DataCube<LongOp> cube, int finalI) {
+        final Address address = new Address(cube);
+        address.at(dimension, Ints.toByteArray(finalI));
+        return address;
+    }
+
+    private static class Adder implements Supplier<Boolean> {
+        private final int each;
+        private final ThreadsafeBatch<LongOp> batch;
+        private Address[] address;
+
+        public Adder(int each, ThreadsafeBatch<LongOp> batch, Address... address) {
+            this.each = each;
+            this.batch = batch;
+            this.address = address;
+        }
+
+        @Override
+        public Boolean get() {
+            for (int i = 0; i < each; ++i) {
+                try {
+                    ImmutableMap.Builder<Address, LongOp> builder = ImmutableMap.builder();
+
+                    for (Address a : address) {
+                        builder.put(a, new LongOp(1));
+                    }
+
+                    batch.put(builder.build());
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            return true;
+        }
+    }
+}

--- a/src/test/java/com/urbanairship/datacube/dbharnesses/HbaseBatchDbHarnessTest.java
+++ b/src/test/java/com/urbanairship/datacube/dbharnesses/HbaseBatchDbHarnessTest.java
@@ -1,0 +1,123 @@
+package com.urbanairship.datacube.dbharnesses;
+
+import com.google.common.collect.ImmutableList;
+import com.urbanairship.datacube.Address;
+import com.urbanairship.datacube.Batch;
+import com.urbanairship.datacube.DataCube;
+import com.urbanairship.datacube.DbHarness;
+import com.urbanairship.datacube.Dimension;
+import com.urbanairship.datacube.EmbeddedClusterTestAbstract;
+import com.urbanairship.datacube.IdService;
+import com.urbanairship.datacube.ReadBuilder;
+import com.urbanairship.datacube.Rollup;
+import com.urbanairship.datacube.WriteBuilder;
+import com.urbanairship.datacube.bucketers.BigEndianLongBucketer;
+import com.urbanairship.datacube.idservices.HBaseIdService;
+import com.urbanairship.datacube.ops.LongOp;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.client.HTablePool;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class HbaseBatchDbHarnessTest extends EmbeddedClusterTestAbstract {
+    final private static byte[] table = "testing".getBytes();
+    final private static byte[] cube = "cube".getBytes();
+    final private static byte[] id = "id".getBytes();
+    final private static byte[] counter = "counter".getBytes();
+    final private static byte[] cf = "c".getBytes();
+    private static IdService idService;
+    private static HTablePool pool;
+    private static DataCube<LongOp> dataCube;
+    private static Dimension<Long> dim1;
+    private static Dimension<Long> dim2;
+
+    @org.junit.BeforeClass
+    public static void setUp() throws Exception {
+        getTestUtil().createTable(table, cf).close();
+        getTestUtil().createTable(id, cf).close();
+        getTestUtil().createTable(counter, cf).close();
+
+    }
+
+    private static final Logger log = LogManager.getLogger(HbaseBatchDbHarnessTest.class);
+
+    @Test
+    public void matchesHbaseDbHarness() throws Exception {
+        Configuration conf = getTestUtil().getConfiguration();
+        idService = new HBaseIdService(conf, id, counter, cf, cube);
+        pool = new HTablePool(conf, Integer.MAX_VALUE);
+        dim1 = new Dimension<Long>("1", new BigEndianLongBucketer(),
+                true, 2);
+        dim2 = new Dimension<Long>("2", new BigEndianLongBucketer(),
+                false, 8);
+
+        List<Dimension<?>> dimensions = ImmutableList.<Dimension<?>>of(dim1, dim2);
+
+        dataCube = new DataCube<LongOp>(dimensions, ImmutableList.of(new Rollup(dim1, dim2), new Rollup(dim1), new Rollup(dim2)));
+        HbaseBatchDbHarness hot = new HbaseBatchDbHarness(cube, table, cf, "testing", idService, pool);
+        HBaseDbHarness<LongOp> old = new HBaseDbHarness<LongOp>(pool, cube, table, cf, LongOp.DESERIALIZER, idService, DbHarness.CommitType.INCREMENT);
+
+        WriteBuilder writeBuilder = new WriteBuilder();
+        writeBuilder.at(dim1, 1l);
+        writeBuilder.at(dim2, 2l);
+
+        CompletableFuture wrote = new CompletableFuture();
+
+        Batch<LongOp> writes = dataCube.getWrites(writeBuilder, new LongOp(1));
+        old.runBatchAsync(writes, new AfterExecute<LongOp>() {
+            @Override
+            public void afterExecute(Throwable t) {
+                if (t != null) {
+                    wrote.completeExceptionally(t);
+                } else {
+                    wrote.complete(null);
+                }
+            }
+        });
+        old.flush();
+        log.info("waiting for old write");
+        wrote.join();
+        log.info("finished writing old write");
+
+        Map<Address, LongOp> map = writes.getMap();
+        log.info("writing new " + map);
+        hot.increment(map, attempt -> {
+            if (attempt > 0) {
+                return false;
+            }
+            return true;
+        });
+        log.info("finished writing new");
+
+        List<Optional<LongOp>> optionals = old.multiGet(ImmutableList.of(
+                new ReadBuilder(dataCube).at(dim1, 1L).build(),
+                new ReadBuilder(dataCube).at(dim2, 2L).build(),
+                new ReadBuilder(dataCube).at(dim1, 1L).at(dim2, 2L).build()
+        ));
+
+        List<Long> collect = optionals.stream()
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .map(LongOp::getLong)
+                .collect(Collectors.toList());
+
+        assertEquals(collect, ImmutableList.of(2L, 2L, 2L));
+
+
+    }
+
+
+    @org.junit.After
+    public void tearDown() throws Exception {
+    }
+}


### PR DESCRIPTION
does so in two ways:

1. just bang it in to the old and busted db harness
2. reimplement the write operations (both the buffering that datacubeio
   does and the application of increment operatios to the database) on
   new interfaces, and in a fashion that is perhaps less daunting to
   modify.

TODO:

- tests
- release notes
- additional documentation
- pick one way and stick with it.
- probably best to move the new hotness into a different module for clarity.