### PR TITLE
add batch increment operation to hbase db harness

### DIFF
--- a/src/main/java/com/urbanairship/datacube/DbHarness.java
+++ b/src/main/java/com/urbanairship/datacube/DbHarness.java
@@ -54,6 +54,16 @@ public interface DbHarness<T extends Op> {
     List<Optional<T>> multiGet(List<Address> addresses) throws IOException, InterruptedException;
 
     /**
+     * A hook for shutting down any internal threads during orderly shutdown. The default implementation simply calls
+     * {@link #flush}
+     *
+     * @throws Exception
+     */
+    default void shutdown() throws Exception {
+        flush();
+    }
+
+    /**
      * When it's time to write a batch to the database, there are a couple of ways it can
      * be done.
      *

--- a/src/main/java/com/urbanairship/datacube/DbHarness.java
+++ b/src/main/java/com/urbanairship/datacube/DbHarness.java
@@ -59,7 +59,7 @@ public interface DbHarness<T extends Op> {
      *
      * @throws Exception
      */
-    default void shutdown() throws Exception {
+    default void shutdown() throws IOException, InterruptedException {
         flush();
     }
 

--- a/src/main/java/com/urbanairship/datacube/dbharnesses/HBaseDbHarness.java
+++ b/src/main/java/com/urbanairship/datacube/dbharnesses/HBaseDbHarness.java
@@ -8,6 +8,7 @@ import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Timer;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
@@ -312,14 +313,10 @@ public class HBaseDbHarness<T extends Op> implements DbHarness<T> {
         ImmutableMap.Builder<BoxedByteArray, byte[]> successes = ImmutableMap.builder();
 
         List<Row> increments = new ArrayList<>();
+        List<Map.Entry<BoxedByteArray, T>> entries = ImmutableList.copyOf(writes.entrySet());
 
-        List<Map.Entry<BoxedByteArray, byte[]>> entries = writes.entrySet().stream()
-                .map(e -> new AbstractMap.SimpleEntry<BoxedByteArray, byte[]>(e.getKey(), e.getValue().serialize()))
-                .collect(Collectors.toList());
-
-
-        for (Map.Entry<BoxedByteArray, byte[]> entry : entries) {
-            long amount = Bytes.toLong(entry.getValue());
+        for (Map.Entry<BoxedByteArray, T> entry : entries) {
+            long amount = Bytes.toLong(entry.getValue().serialize());
             Increment increment = new Increment(entry.getKey().bytes);
             increment.addColumn(cf, QUALIFIER, amount);
             incrementSize.update(amount);

--- a/src/main/java/com/urbanairship/datacube/dbharnesses/HBaseDbHarness.java
+++ b/src/main/java/com/urbanairship/datacube/dbharnesses/HBaseDbHarness.java
@@ -298,7 +298,7 @@ public class HBaseDbHarness<T extends Op> implements DbHarness<T> {
     }
 
     /**
-     * @param writes map from rowkey to the operation (which had better bet bytes compatible with long
+     * @param writes map from rowkey to the operation (which had better be bytes compatible with long)
      *
      * @return A map from bytes to the amounts successfully added to the database.
      *

--- a/src/main/java/com/urbanairship/datacube/dbharnesses/HBaseDbHarness.java
+++ b/src/main/java/com/urbanairship/datacube/dbharnesses/HBaseDbHarness.java
@@ -13,6 +13,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.google.common.primitives.UnsignedBytes;
 import com.urbanairship.datacube.Address;
 import com.urbanairship.datacube.Batch;
 import com.urbanairship.datacube.BoxedByteArray;
@@ -388,7 +389,7 @@ public class HBaseDbHarness<T extends Op> implements DbHarness<T> {
         Map<Address, T> batchMap = batch.getMap();
 
         List<Address> successfulAddresses = Lists.newArrayListWithExpectedSize(batchMap.size());
-        Map<byte[], byte[]> successfulRows = Maps.newHashMap();
+        Map<byte[], byte[]> successfulRows = Maps.newTreeMap(UnsignedBytes.lexicographicalComparator());
 
         long nanoTimeBeforeBatch = System.nanoTime();
 

--- a/src/main/java/com/urbanairship/datacube/dbharnesses/HBaseDbHarness.java
+++ b/src/main/java/com/urbanairship/datacube/dbharnesses/HBaseDbHarness.java
@@ -300,7 +300,7 @@ public class HBaseDbHarness<T extends Op> implements DbHarness<T> {
     /**
      * @param writes map from rowkey to the operation (which had better be bytes compatible with long)
      *
-     * @return A map from bytes to the amounts successfully added to the database.
+     * @return A map from bytes to the new values written to the database.
      *
      * @throws IOException
      * @throws InterruptedException
@@ -327,7 +327,9 @@ public class HBaseDbHarness<T extends Op> implements DbHarness<T> {
 
         for (int i = 0; i < objects.length; ++i) {
             if (objects[i] != null) {
-                successes.put(entries.get(i));
+                Result result = (Result) objects[i];
+                byte[] value = result.getValue(cf, QUALIFIER);
+                successes.put(entries.get(i).getKey(), value);
             }
         }
 

--- a/src/main/java/com/urbanairship/datacube/dbharnesses/HBaseDbHarness.java
+++ b/src/main/java/com/urbanairship/datacube/dbharnesses/HBaseDbHarness.java
@@ -429,8 +429,9 @@ public class HBaseDbHarness<T extends Op> implements DbHarness<T> {
                 if (successfulAddresses.size() < batchMap.size()) {
                     // the implementation prior to the addition of the batch increment code assumes any failed increment
                     // operation results in an io exception. This matches that expectation.
-                    incrementFailuresPerFlush.update(batchMap.size() - successfulAddresses.size());
-                    throw new IOException("Some writes failed; queueing retry");
+                    int failures = batchMap.size() - successfulAddresses.size();
+                    incrementFailuresPerFlush.update(failures);
+                    throw new IOException(String.format("Some writes failed (%s of %s attempted); queueing retry", failures, batchMap.size()));
                 }
             } else {
                 for (Map.Entry<Address, T> entry : batchMap.entrySet()) {

--- a/src/main/java/com/urbanairship/datacube/dbharnesses/HbaseDbHarnessConfiguration.java
+++ b/src/main/java/com/urbanairship/datacube/dbharnesses/HbaseDbHarnessConfiguration.java
@@ -1,0 +1,132 @@
+package com.urbanairship.datacube.dbharnesses;
+
+import com.google.common.base.Preconditions;
+import com.urbanairship.datacube.DbHarness;
+
+public class HbaseDbHarnessConfiguration {
+    /**
+     * Your unique cube name, gets appended to the front of the key.
+     */
+    public final byte[] uniqueCubeName;
+
+    /**
+     * The hbase table name that stores the cube
+     */
+    public final byte[] tableName;
+
+    /**
+     * The hbase column family in which counts are stored
+     */
+    public final byte[] cf;
+
+    public final DbHarness.CommitType commitType;
+    /**
+     * The number of threads for flushing batches to hbase
+     */
+    public final int numFlushThreads;
+    public static final int DEFAULT_NUM_FLUSH_THREADS = 5;
+
+    /**
+     * How many times we should retry io exceptions
+     */
+    public final int numIoeTries;
+    public static final int DEFAULT_NUM_IO_TRIES = 5;
+    /**
+     * How many times we should try compare and swaps (we won't apply updates if the existing value is different from
+     * expectation)
+     */
+    public final int numCasTries;
+    public static final int DEFAULT_NUM_CAS_TRIES = 10;
+
+    /**
+     * A string for disambiguating metrics from this datacube from others
+     */
+    public final String metricsScope;
+
+    /**
+     * The max size of batch database operations, currently only used for deciding how many increments to execute at
+     * once.
+     */
+    public final int batchSize;
+    public static final int DEFAULT_BATCH_SIZE = 10;
+
+    private HbaseDbHarnessConfiguration(Builder builder) {
+        uniqueCubeName = Preconditions.checkNotNull(builder.uniqueCubeName);
+        tableName = Preconditions.checkNotNull(builder.tableName);
+        cf = Preconditions.checkNotNull(builder.cf);
+        commitType = Preconditions.checkNotNull(builder.commitType);
+        numFlushThreads = builder.numFlushThreads;
+        numIoeTries = builder.numIoeTries;
+        numCasTries = builder.numCasTries;
+        metricsScope = builder.metricsScope;
+        batchSize = builder.batchSize;
+    }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private byte[] uniqueCubeName;
+        private byte[] tableName;
+        private byte[] cf;
+        private DbHarness.CommitType commitType;
+        private int numFlushThreads = DEFAULT_NUM_FLUSH_THREADS;
+        private int numIoeTries = DEFAULT_NUM_IO_TRIES;
+        private int numCasTries = DEFAULT_NUM_CAS_TRIES;
+        private String metricsScope;
+        private int batchSize = DEFAULT_BATCH_SIZE;
+
+        private Builder() {
+        }
+
+        public Builder setUniqueCubeName(byte[] uniqueCubeName) {
+            this.uniqueCubeName = uniqueCubeName;
+            return this;
+        }
+
+        public Builder setTableName(byte[] tableName) {
+            this.tableName = tableName;
+            return this;
+        }
+
+        public Builder setCf(byte[] cf) {
+            this.cf = cf;
+            return this;
+        }
+
+        public Builder setCommitType(DbHarness.CommitType commitType) {
+            this.commitType = commitType;
+            return this;
+        }
+
+        public Builder setNumFlushThreads(int numFlushThreads) {
+            this.numFlushThreads = numFlushThreads;
+            return this;
+        }
+
+        public Builder setNumIoeTries(int numIoeTries) {
+            this.numIoeTries = numIoeTries;
+            return this;
+        }
+
+        public Builder setNumCasTries(int numCasTries) {
+            this.numCasTries = numCasTries;
+            return this;
+        }
+
+        public Builder setMetricsScope(String metricsScope) {
+            this.metricsScope = metricsScope;
+            return this;
+        }
+
+        public Builder setBatchSize(int batchSize) {
+            this.batchSize = batchSize;
+            return this;
+        }
+
+        public HbaseDbHarnessConfiguration build() {
+            return new HbaseDbHarnessConfiguration(this);
+        }
+    }
+}

--- a/src/main/java/com/urbanairship/datacube/dbharnesses/HbaseDbHarnessConfiguration.java
+++ b/src/main/java/com/urbanairship/datacube/dbharnesses/HbaseDbHarnessConfiguration.java
@@ -50,6 +50,9 @@ public class HbaseDbHarnessConfiguration {
     public final int batchSize;
     public static final int DEFAULT_BATCH_SIZE = 10;
 
+    public final int idServiceLookupThreads;
+    public final static int DEFAULT_ID_SERVICE_LOOKUP_THREADS = 100;
+
     private HbaseDbHarnessConfiguration(Builder builder) {
         uniqueCubeName = Preconditions.checkNotNull(builder.uniqueCubeName);
         tableName = Preconditions.checkNotNull(builder.tableName);
@@ -60,6 +63,7 @@ public class HbaseDbHarnessConfiguration {
         numCasTries = builder.numCasTries;
         metricsScope = builder.metricsScope;
         batchSize = builder.batchSize;
+        idServiceLookupThreads = builder.idServiceLookupThreads;
     }
 
     public static Builder newBuilder() {
@@ -76,6 +80,7 @@ public class HbaseDbHarnessConfiguration {
         private int numCasTries = DEFAULT_NUM_CAS_TRIES;
         private String metricsScope;
         private int batchSize = DEFAULT_BATCH_SIZE;
+        private int idServiceLookupThreads = DEFAULT_ID_SERVICE_LOOKUP_THREADS;
 
         private Builder() {
         }
@@ -122,6 +127,11 @@ public class HbaseDbHarnessConfiguration {
 
         public Builder setBatchSize(int batchSize) {
             this.batchSize = batchSize;
+            return this;
+        }
+
+        public Builder setIdServiceLookupThreads(int idServiceLookupThreads) {
+            this.idServiceLookupThreads = idServiceLookupThreads;
             return this;
         }
 

--- a/src/test/java/com/urbanairship/datacube/DbHarnessTests.java
+++ b/src/test/java/com/urbanairship/datacube/DbHarnessTests.java
@@ -13,7 +13,9 @@ import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Assert;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 public class DbHarnessTests {
@@ -162,5 +164,76 @@ public class DbHarnessTests {
 
         missingCount = optionals.get(5);
         Assert.assertFalse(missingCount.isPresent());
+    }
+
+    public static void asyncBatchWritesTest(DbHarness<LongOp> dbHarness, int writes) throws Exception {
+        HourDayMonthBucketer hourDayMonthBucketer = new HourDayMonthBucketer();
+
+        Dimension<DateTime> time = new Dimension<DateTime>("time", hourDayMonthBucketer, false, 8);
+        Dimension<String> zipcode = new Dimension<String>("zipcode", new StringToBytesBucketer(),
+                true, 5);
+
+        DataCubeIo<LongOp> cubeIo;
+        DataCube<LongOp> cube;
+
+        Rollup hourAndZipRollup = new Rollup(zipcode, time, HourDayMonthBucketer.hours);
+        Rollup dayAndZipRollup = new Rollup(zipcode, time, HourDayMonthBucketer.days);
+        Rollup hourRollup = new Rollup(time, HourDayMonthBucketer.hours);
+        Rollup dayRollup = new Rollup(time, HourDayMonthBucketer.days);
+
+        List<Dimension<?>> dimensions = ImmutableList.<Dimension<?>>of(time, zipcode);
+        List<Rollup> rollups = ImmutableList.of(hourAndZipRollup, dayAndZipRollup, hourRollup,
+                dayRollup);
+
+        cube = new DataCube<LongOp>(dimensions, rollups);
+
+        cubeIo = new DataCubeIo<LongOp>(cube, dbHarness, 1, Long.MAX_VALUE, SyncLevel.FULL_SYNC);
+
+        DateTime now = new DateTime(DateTimeZone.UTC);
+        DateTime differentHour = now.withHourOfDay((now.getHourOfDay() + 1) % 24);
+
+        Map<DateTime, Long> ohOneExpected = new HashMap<>();
+        Map<DateTime, Long> ohTwoExpected = new HashMap<>();
+
+
+        for (int i = 0; i < writes; ++i) {
+            // Do an increment of 10 for the same zipcode in a different hour of the same day
+            DateTime hour = now.withHourOfDay((now.getHourOfDay() + i) % 24);
+            cubeIo.writeAsync(new LongOp(10), new WriteBuilder()
+                    .at(time, hour)
+                    .at(zipcode, "97201"));
+            ohOneExpected.merge(hour, 10L, Long::sum);
+
+            // Do an increment of 10 for the same zipcode in a different hour of the same day
+            cubeIo.writeAsync(new LongOp(5), new WriteBuilder()
+                    .at(time, hour)
+                    .at(zipcode, "97202"));
+            ohTwoExpected.merge(hour, 5L, Long::sum);
+        }
+
+        dbHarness.flush();
+
+        // Read back the value that we wrote for the current hour, should be 5
+        Optional<LongOp> thisHourCount = cubeIo.get(new ReadBuilder(cube)
+                .at(time, HourDayMonthBucketer.hours, now)
+                .at(zipcode, "97201"));
+
+        // Read back the value we wrote for the other hour, should be 10
+        Optional<LongOp> differentHourCount = cubeIo.get(new ReadBuilder(cube)
+                .at(time, HourDayMonthBucketer.hours, differentHour)
+                .at(zipcode, "97201"));
+
+        // The total for today should be the sum of the two increments
+        Optional<LongOp> todayCount = cubeIo.get(new ReadBuilder(cube)
+                .at(time, HourDayMonthBucketer.days, now)
+                .at(zipcode, "97201"));
+
+        Assert.assertTrue(differentHourCount.isPresent());
+        Assert.assertEquals(ohOneExpected.get(differentHour).longValue(), differentHourCount.get().getLong());
+        Assert.assertTrue(thisHourCount.isPresent());
+        Assert.assertEquals(ohOneExpected.get(now).longValue(), thisHourCount.get().getLong());
+        Assert.assertTrue(todayCount.isPresent());
+        Assert.assertEquals(ohOneExpected.values().stream().mapToLong(Long::longValue).sum() , todayCount.get().getLong());
+        dbHarness.shutdown();
     }
 }

--- a/src/test/java/com/urbanairship/datacube/DbHarnessTests.java
+++ b/src/test/java/com/urbanairship/datacube/DbHarnessTests.java
@@ -199,6 +199,7 @@ public class DbHarnessTests {
         for (int i = 0; i < writes; ++i) {
             // Do an increment of 10 for the same zipcode in a different hour of the same day
             DateTime hour = now.withHourOfDay((now.getHourOfDay() + i) % 24);
+            System.out.println(hour);
             cubeIo.writeAsync(new LongOp(10), new WriteBuilder()
                     .at(time, hour)
                     .at(zipcode, "97201"));

--- a/src/test/java/com/urbanairship/datacube/DbHarnessTests.java
+++ b/src/test/java/com/urbanairship/datacube/DbHarnessTests.java
@@ -199,16 +199,15 @@ public class DbHarnessTests {
         for (int i = 0; i < writes; ++i) {
             // Do an increment of 10 for the same zipcode in a different hour of the same day
             DateTime hour = now.withHourOfDay((now.getHourOfDay() + i) % 24);
-            System.out.println(hour);
             cubeIo.writeAsync(new LongOp(10), new WriteBuilder()
                     .at(time, hour)
-                    .at(zipcode, "97201"));
+                    .at(zipcode, "97001"));
             ohOneExpected.merge(hour, 10L, Long::sum);
 
             // Do an increment of 10 for the same zipcode in a different hour of the same day
             cubeIo.writeAsync(new LongOp(5), new WriteBuilder()
                     .at(time, hour)
-                    .at(zipcode, "97202"));
+                    .at(zipcode, "97002"));
             ohTwoExpected.merge(hour, 5L, Long::sum);
         }
 
@@ -217,17 +216,17 @@ public class DbHarnessTests {
         // Read back the value that we wrote for the current hour, should be 5
         Optional<LongOp> thisHourCount = cubeIo.get(new ReadBuilder(cube)
                 .at(time, HourDayMonthBucketer.hours, now)
-                .at(zipcode, "97201"));
+                .at(zipcode, "97001"));
 
         // Read back the value we wrote for the other hour, should be 10
         Optional<LongOp> differentHourCount = cubeIo.get(new ReadBuilder(cube)
                 .at(time, HourDayMonthBucketer.hours, differentHour)
-                .at(zipcode, "97201"));
+                .at(zipcode, "97001"));
 
         // The total for today should be the sum of the two increments
         Optional<LongOp> todayCount = cubeIo.get(new ReadBuilder(cube)
                 .at(time, HourDayMonthBucketer.days, now)
-                .at(zipcode, "97201"));
+                .at(zipcode, "97001"));
 
         Assert.assertTrue(differentHourCount.isPresent());
         Assert.assertEquals(ohOneExpected.get(differentHour).longValue(), differentHourCount.get().getLong());

--- a/src/test/java/com/urbanairship/datacube/HBaseHarnessTest.java
+++ b/src/test/java/com/urbanairship/datacube/HBaseHarnessTest.java
@@ -1,6 +1,5 @@
 package com.urbanairship.datacube;
 
-import com.google.common.base.Function;
 import com.google.common.collect.ImmutableList;
 import com.urbanairship.datacube.bucketers.HourDayMonthBucketer;
 import com.urbanairship.datacube.bucketers.StringToBytesBucketer;
@@ -20,6 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
 
 public class HBaseHarnessTest extends EmbeddedClusterTestAbstract {
     public static final byte[] DATA_CUBE_TABLE = "data_cube" .getBytes();
@@ -54,7 +54,7 @@ public class HBaseHarnessTest extends EmbeddedClusterTestAbstract {
         HTablePool pool = new HTablePool(getTestUtil().getConfiguration(), Integer.MAX_VALUE);
         DbHarness<LongOp> hbaseDbHarness = new HBaseDbHarness<LongOp>(pool,
                 "dh" .getBytes(), DATA_CUBE_TABLE, CF, LongOp.DESERIALIZER, idService,
-                DbHarness.CommitType.INCREMENT, new TestCallback(s), 1, 1, 1, "none");
+                DbHarness.CommitType.INCREMENT, new TestCallback(s), 1, 1, 1, "none", 1);
         // Do an increment of 5 for a certain time and zipcode
         DataCubeIo<LongOp> dataCubeIo = new DataCubeIo<LongOp>(dataCube, hbaseDbHarness, 1, 100000, SyncLevel.BATCH_SYNC);
 

--- a/src/test/java/com/urbanairship/datacube/HBaseTest.java
+++ b/src/test/java/com/urbanairship/datacube/HBaseTest.java
@@ -10,19 +10,19 @@ import com.urbanairship.datacube.dbharnesses.HbaseDbHarnessConfiguration;
 import com.urbanairship.datacube.idservices.HBaseIdService;
 import com.urbanairship.datacube.idservices.MapIdService;
 import com.urbanairship.datacube.ops.LongOp;
-import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.client.HTablePool;
+import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import static org.mockito.Mockito.mock;
+import java.util.stream.Collectors;
 
 public class HBaseTest extends EmbeddedClusterTestAbstract {
-    public static final byte[] CUBE_DATA_TABLE = "cube_data" .getBytes();
-    public static final byte[] IDSERVICE_LOOKUP_TABLE = "idservice_data" .getBytes();
-    public static final byte[] IDSERVICE_COUNTER_TABLE = "idservice_counter" .getBytes();
+    public static final byte[] CUBE_DATA_TABLE = "cube_data".getBytes();
+    public static final byte[] IDSERVICE_LOOKUP_TABLE = "idservice_data".getBytes();
+    public static final byte[] IDSERVICE_COUNTER_TABLE = "idservice_counter".getBytes();
 
-    public static final byte[] CF = "c" .getBytes();
+    public static final byte[] CF = "c".getBytes();
 
     @BeforeClass
     public static void setupCluster() throws Exception {
@@ -37,7 +37,7 @@ public class HBaseTest extends EmbeddedClusterTestAbstract {
 
         HTablePool pool = new HTablePool(getTestUtil().getConfiguration(), Integer.MAX_VALUE);
         DbHarness<LongOp> hbaseDbHarness = new HBaseDbHarness<LongOp>(pool,
-                "hbaseForCubeDataTest" .getBytes(), CUBE_DATA_TABLE, CF, LongOp.DESERIALIZER, idService,
+                "hbaseForCubeDataTest".getBytes(), CUBE_DATA_TABLE, CF, LongOp.DESERIALIZER, idService,
                 CommitType.INCREMENT);
 
         DbHarnessTests.basicTest(hbaseDbHarness);
@@ -57,7 +57,7 @@ public class HBaseTest extends EmbeddedClusterTestAbstract {
                 .setCommitType(CommitType.INCREMENT)
                 .build();
 
-        DbHarness<LongOp> hbaseDbHarness = new HBaseDbHarness<LongOp>(config, pool, LongOp.DESERIALIZER, idService, (avoid) -> null);
+        DbHarness<LongOp> hbaseDbHarness = new HBaseDbHarness<LongOp>(config, pool, LongOp.DESERIALIZER, idService, (results) -> null);
 
         DbHarnessTests.asyncBatchWritesTest(hbaseDbHarness, 30);
     }
@@ -68,7 +68,7 @@ public class HBaseTest extends EmbeddedClusterTestAbstract {
 
         HTablePool pool = new HTablePool(getTestUtil().getConfiguration(), Integer.MAX_VALUE);
         DbHarness<LongOp> hbaseDbHarness = new HBaseDbHarness<LongOp>(pool,
-                "hbaseForCubeDataTest" .getBytes(), CUBE_DATA_TABLE, CF, LongOp.DESERIALIZER, idService,
+                "hbaseForCubeDataTest".getBytes(), CUBE_DATA_TABLE, CF, LongOp.DESERIALIZER, idService,
                 CommitType.INCREMENT);
 
         DbHarnessTests.multiGetTest(hbaseDbHarness);
@@ -79,7 +79,7 @@ public class HBaseTest extends EmbeddedClusterTestAbstract {
     public void basicIdServiceTest() throws Exception {
         IdService idService = new HBaseIdService(getTestUtil().getConfiguration(),
                 IDSERVICE_LOOKUP_TABLE, IDSERVICE_COUNTER_TABLE, CF,
-                "basicIdServiceTest" .getBytes());
+                "basicIdServiceTest".getBytes());
 
         IdServiceTests.basicTest(idService);
     }
@@ -88,7 +88,7 @@ public class HBaseTest extends EmbeddedClusterTestAbstract {
     public void exhaustionIdServiceTest() throws Exception {
         IdService idService = new HBaseIdService(getTestUtil().getConfiguration(),
                 IDSERVICE_LOOKUP_TABLE, IDSERVICE_COUNTER_TABLE, CF,
-                "exhaustionIdServiceTest" .getBytes());
+                "exhaustionIdServiceTest".getBytes());
         IdServiceTests.testExhaustion(idService, 1, 1);
     }
 }

--- a/src/test/java/com/urbanairship/datacube/HBaseTest.java
+++ b/src/test/java/com/urbanairship/datacube/HBaseTest.java
@@ -59,26 +59,9 @@ public class HBaseTest extends EmbeddedClusterTestAbstract {
 
         DbHarness<LongOp> hbaseDbHarness = new HBaseDbHarness<LongOp>(config, pool, LongOp.DESERIALIZER, idService, (avoid) -> null);
 
-        DbHarnessTests.asyncBatchWritesTest(hbaseDbHarness, 10);
+        DbHarnessTests.asyncBatchWritesTest(hbaseDbHarness, 30);
     }
 
-    @Test
-    public void mockedHbaseTest() throws Exception {
-        IdService idService = new MapIdService();
-        HTablePool pool = mock(HTablePool.class);
-
-        HbaseDbHarnessConfiguration config = HbaseDbHarnessConfiguration.newBuilder()
-                .setBatchSize(10)
-                .setUniqueCubeName("hbaseForCubeDataTest".getBytes())
-                .setTableName(CUBE_DATA_TABLE)
-                .setCf(CF)
-                .setCommitType(CommitType.INCREMENT)
-                .build();
-
-        DbHarness<LongOp> hbaseDbHarness = new HBaseDbHarness<LongOp>(config, pool, LongOp.DESERIALIZER, idService, (avoid) -> null);
-
-        DbHarnessTests.asyncBatchWritesTest(hbaseDbHarness, 10);
-    }
     @Test
     public void hbaseForCubeDataTestMulti() throws Exception {
         IdService idService = new MapIdService();

--- a/src/test/java/com/urbanairship/datacube/MockHbaseHbaseDbHarnessTest.java
+++ b/src/test/java/com/urbanairship/datacube/MockHbaseHbaseDbHarnessTest.java
@@ -19,9 +19,7 @@ import java.util.List;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyList;
 import static org.mockito.Mockito.atLeast;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 

--- a/src/test/java/com/urbanairship/datacube/MockHbaseHbaseDbHarnessTest.java
+++ b/src/test/java/com/urbanairship/datacube/MockHbaseHbaseDbHarnessTest.java
@@ -1,0 +1,77 @@
+package com.urbanairship.datacube;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.primitives.Longs;
+import com.urbanairship.datacube.dbharnesses.HBaseDbHarness;
+import com.urbanairship.datacube.dbharnesses.HbaseDbHarnessConfiguration;
+import com.urbanairship.datacube.idservices.MapIdService;
+import com.urbanairship.datacube.ops.LongOp;
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.HTableInterface;
+import org.apache.hadoop.hbase.client.HTablePool;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.Row;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyList;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class MockHbaseHbaseDbHarnessTest {
+
+    private byte[] CUBE_DATA_TABLE = "table".getBytes();
+    private byte[] CF = "c".getBytes();
+
+    @Test
+    public void test() throws Exception {
+        IdService idService = new MapIdService();
+
+        HTablePool pool = mock(HTablePool.class);
+        HTableInterface htableInterface = mock(HTableInterface.class);
+
+        when(pool.getTable(any(byte[].class))).thenReturn(htableInterface);
+        when(htableInterface.batch(anyList()))
+                .thenAnswer(a -> {
+                    List<Row> arguments = (List<Row>) a.getArguments()[0];
+                    int size = arguments.size();
+                    if (size < 3) {
+                        return arguments;
+                    }
+                    Object[] objects = new Object[size];
+
+                    for (int i = 0; i < size; ++i) {
+                        if (i % 2 == 0) {
+                            objects[i] = null;
+                        }
+                        objects[i] = new Object();
+                    }
+                    return objects;
+                });
+
+        HbaseDbHarnessConfiguration config = HbaseDbHarnessConfiguration.newBuilder()
+                .setBatchSize(100)
+                .setUniqueCubeName("hbaseForCubeDataTest".getBytes())
+                .setTableName(CUBE_DATA_TABLE)
+                .setCf(CF)
+                .setCommitType(DbHarness.CommitType.INCREMENT)
+                .build();
+
+        DbHarness<LongOp> hbaseDbHarness = new HBaseDbHarness<LongOp>(config, pool, LongOp.DESERIALIZER, idService, (avoid) -> null);
+
+        when(htableInterface.get(any(Get.class))).thenReturn(getResult(10L), getResult(10L), getResult(100L));
+        DbHarnessTests.asyncBatchWritesTest(hbaseDbHarness, 10);
+        verify(htableInterface, atLeast(2)).batch(anyList());
+    }
+
+    private Result getResult(long value) {
+        return new Result(ImmutableList.of(new KeyValue(new byte[]{}, new byte[]{}, new byte[]{}, Longs.toByteArray(value))));
+    }
+}

--- a/src/test/java/com/urbanairship/datacube/MockHbaseHbaseDbHarnessTest.java
+++ b/src/test/java/com/urbanairship/datacube/MockHbaseHbaseDbHarnessTest.java
@@ -12,6 +12,7 @@ import org.apache.hadoop.hbase.client.HTableInterface;
 import org.apache.hadoop.hbase.client.HTablePool;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.Row;
+import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Test;
 
 import java.util.List;
@@ -40,16 +41,18 @@ public class MockHbaseHbaseDbHarnessTest {
                 .thenAnswer(a -> {
                     List<Row> arguments = (List<Row>) a.getArguments()[0];
                     int size = arguments.size();
-                    if (size < 3) {
-                        return arguments;
-                    }
                     Object[] objects = new Object[size];
 
                     for (int i = 0; i < size; ++i) {
-                        if (i % 2 == 0) {
+                        if (i % 2 == 1) {
                             objects[i] = null;
                         }
-                        objects[i] = new Object();
+                        objects[i] = new Result(new KeyValue[]{new KeyValue(
+                                arguments.get(i).getRow(),
+                                CF,
+                                HBaseDbHarness.QUALIFIER,
+                                Longs.toByteArray(10L)
+                        )});
                     }
                     return objects;
                 });


### PR DESCRIPTION
this lets us have each flusher increment more than a single row in each
request, which should improve performance when writing a large number
of dimensions either because we have many rollups, or because the batch
increments many different rows.

Also adds a configuration object to the hbasedb harness, since the number
of primitive parameters has grown somewhat out of hand.

Also adds a shutdown method to the hbasedbharness that flushes the inflight messages and then shutsdown the threadpool