### PR TITLE
Increment fixes

### DIFF
--- a/src/main/java/com/urbanairship/datacube/Batch.java
+++ b/src/main/java/com/urbanairship/datacube/Batch.java
@@ -4,7 +4,6 @@ Copyright 2012 Urban Airship and Contributors
 
 package com.urbanairship.datacube;
 
-import com.google.common.base.Objects;
 import com.google.common.collect.Maps;
 
 import java.util.Map;

--- a/src/main/java/com/urbanairship/datacube/Batch.java
+++ b/src/main/java/com/urbanairship/datacube/Batch.java
@@ -4,6 +4,7 @@ Copyright 2012 Urban Airship and Contributors
 
 package com.urbanairship.datacube;
 
+import com.google.common.base.Objects;
 import com.google.common.collect.Maps;
 
 import java.util.Map;

--- a/src/main/java/com/urbanairship/datacube/dbharnesses/HbaseBatchIncrementer.java
+++ b/src/main/java/com/urbanairship/datacube/dbharnesses/HbaseBatchIncrementer.java
@@ -24,7 +24,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Package private class incrementing all the batch increment operations accomplished by the datacube
+ * Package private class implementing all the batch increment operations accomplished by the hbase dbharness
  *
  * @param <T>
  */

--- a/src/main/java/com/urbanairship/datacube/dbharnesses/HbaseBatchIncrementer.java
+++ b/src/main/java/com/urbanairship/datacube/dbharnesses/HbaseBatchIncrementer.java
@@ -1,0 +1,248 @@
+package com.urbanairship.datacube.dbharnesses;
+
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Timer;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import com.urbanairship.datacube.Address;
+import com.urbanairship.datacube.BoxedByteArray;
+import com.urbanairship.datacube.Op;
+import com.urbanairship.datacube.metrics.Metrics;
+import org.apache.hadoop.hbase.client.HTableInterface;
+import org.apache.hadoop.hbase.client.HTablePool;
+import org.apache.hadoop.hbase.client.Increment;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.Row;
+import org.apache.hadoop.hbase.util.Bytes;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Package private class incrementing all the batch increment operations accomplished by the datacube
+ *
+ * @param <T>
+ */
+class HbaseBatchIncrementer<T extends Op> {
+
+    private final HTablePool pool;
+    private final IncrementerMetrics incrementerMetrics;
+    private final BlockingIO<Address, BoxedByteArray> serializer;
+    private HbaseDbHarnessConfiguration configuration;
+
+    interface BlockingIO<I, O> {
+        O apply(I i) throws InterruptedException, IOException;
+    }
+
+    HbaseBatchIncrementer(HbaseDbHarnessConfiguration configuration, HTablePool pool, BlockingIO<Address, BoxedByteArray> serializer) {
+        this.configuration = configuration;
+        this.pool = pool;
+        this.serializer = serializer;
+        this.incrementerMetrics = new IncrementerMetrics(HBaseDbHarness.class, configuration.metricsScope);
+    }
+
+    /**
+     * Slices up the batch map into batches of a reasonable size to send to the database, interprets the results
+     * (include partial failures where only a part of the batch succeeded, and an exception was thrown) and updates
+     * the success map and list with the results. It then rethrows whatever exception resulted from the HBase
+     * interaction.
+     *
+     * @param batchMap            The write operations to accomplish
+     * @param successfulAddresses The datacube address whose writes succeeded
+     * @param successfulRows      A map from HBase row key to the value in the row after completion of the increment
+     *                            operation
+     *
+     * @throws IOException
+     * @throws InterruptedException
+     */
+
+    public void batchIncrement(Map<Address, T> batchMap, List<Address> successfulAddresses, Map<byte[], byte[]> successfulRows) throws IOException, InterruptedException {
+        Iterable<List<Map.Entry<Address, T>>> partitions = Iterables.partition(batchMap.entrySet(), configuration.batchSize);
+
+        CubeIncrementResults.Builder cubeIncrementResultsBuilder = CubeIncrementResults.newBuilder();
+
+        int batchesPerFlush = 0;
+        Map<BoxedByteArray, Address> backwards = new HashMap<>();
+        for (List<Map.Entry<Address, T>> entries : partitions) {
+            Map<BoxedByteArray, T> increments = new HashMap<>();
+            batchesPerFlush++;
+            final long nanoTimeBeforeWrite = System.nanoTime();
+            for (Map.Entry<Address, T> entry : entries) {
+                final Address address = entry.getKey();
+                final BoxedByteArray rowKey = serializer.apply(address);
+
+                increments.put(rowKey, entry.getValue());
+                backwards.put(rowKey, address);
+            }
+
+            cubeIncrementResultsBuilder.add(this.hbaseIncrement(increments));
+
+            long writeDurationNanos = System.nanoTime() - nanoTimeBeforeWrite;
+            incrementerMetrics.batchWritesTimer.update(writeDurationNanos, TimeUnit.NANOSECONDS);
+
+            if (cubeIncrementResultsBuilder.ioException != null) {
+                break;
+            }
+
+            if (cubeIncrementResultsBuilder.interrupt != null) {
+                // still gotto report our successes
+                break;
+            }
+        }
+        incrementerMetrics.batchesPerFlushHisto.update(batchesPerFlush);
+
+        for (Map.Entry<BoxedByteArray, byte[]> entry : cubeIncrementResultsBuilder.successes.entrySet()) {
+            successfulAddresses.add(backwards.get(entry.getKey()));
+            successfulRows.put(entry.getKey().bytes, entry.getValue());
+        }
+
+        int failures = batchMap.size() - successfulAddresses.size();
+
+        if (failures > 0 || cubeIncrementResultsBuilder.ioException != null || cubeIncrementResultsBuilder.interrupt != null) {
+            incrementerMetrics.incrementFailuresPerFlush.update(failures);
+
+            if (cubeIncrementResultsBuilder.ioException != null) {
+                throw cubeIncrementResultsBuilder.ioException;
+            }
+
+            if (cubeIncrementResultsBuilder.interrupt != null) {
+                throw cubeIncrementResultsBuilder.interrupt;
+            }
+
+            // the implementation prior to the addition of the batch increment code assumes any failed increment
+            // operation results in an io exception. This matches that expectation.
+            throw new IOException(String.format("Some writes failed (%s of %s attempted); queueing retry", failures, batchMap.size()), cubeIncrementResultsBuilder.ioException);
+        }
+    }
+
+    /**
+     * @param writes map from rowkey to the operation (which had better be bytes compatible with long)
+     *
+     * @return A map from bytes to the new values written to the database.
+     *
+     * @throws IOException
+     * @throws InterruptedException
+     */
+    public CubeIncrementResults hbaseIncrement(Map<BoxedByteArray, T> writes) throws IOException, InterruptedException {
+        List<Row> increments = new ArrayList<>();
+        List<Map.Entry<BoxedByteArray, T>> entries = ImmutableList.copyOf(writes.entrySet());
+
+        for (Map.Entry<BoxedByteArray, T> entry : entries) {
+            long amount = Bytes.toLong(entry.getValue().serialize());
+            Increment increment = new Increment(entry.getKey().bytes);
+            increment.addColumn(configuration.cf, HBaseDbHarness.QUALIFIER, amount);
+            incrementerMetrics.incrementSize.update(amount);
+            increments.add(increment);
+        }
+
+        return WithHTable.run(pool, configuration.tableName, (HTableInterface hTable) -> {
+            Object[] objects = new Object[entries.size()];
+            CubeIncrementResults.Builder cubeIncrementResultsBuilder = CubeIncrementResults.newBuilder();
+            try {
+                hTable.batch(increments, objects);
+            } catch (InterruptedException e) {
+                cubeIncrementResultsBuilder.setInterrupt(e);
+            } catch (IOException ioe) {
+                cubeIncrementResultsBuilder.setIoException(ioe);
+            }
+
+            Map<BoxedByteArray, byte[]> successes = processBatchCallresults(entries, objects);
+
+            cubeIncrementResultsBuilder.setSuccesses(successes);
+
+            return cubeIncrementResultsBuilder.build();
+        });
+    }
+
+    /**
+     * Converts the datacube request objects and an array of objects returned from an hbase batch call into the map we
+     * use to track success.
+     *
+     * @param entries The map entries we used to construct the increment request against hbase.
+     * @param objects The response to the batch operation
+     *
+     * @return A map from the serialized {@link Address} to the bytes in the column after completion of the operation.
+     */
+    private Map<BoxedByteArray, byte[]> processBatchCallresults(List<Map.Entry<BoxedByteArray, T>> entries, Object[] objects) {
+        Map<BoxedByteArray, byte[]> successes = new HashMap<>();
+        for (int i = 0; i < objects.length; ++i) {
+            if (objects[i] != null && objects[i] instanceof Result) {
+                Result result = (Result) objects[i];
+                byte[] value = result.getValue(configuration.cf, HBaseDbHarness.QUALIFIER);
+                successes.put(entries.get(i).getKey(), value);
+            }
+        }
+        return successes;
+    }
+
+    static class CubeIncrementResults {
+        final IOException ioException;
+        final InterruptedException interrupt;
+        final Map<BoxedByteArray, byte[]> successes;
+
+        CubeIncrementResults(IOException ioException, InterruptedException interrupt, Map<BoxedByteArray, byte[]> successes) {
+            this.ioException = ioException;
+            this.interrupt = interrupt;
+            this.successes = successes;
+        }
+
+        public static Builder newBuilder() {
+            return new Builder();
+        }
+
+        public static class Builder {
+            IOException ioException;
+            InterruptedException interrupt;
+            Map<BoxedByteArray, byte[]> successes = new HashMap<>();
+
+            public Builder setIoException(IOException ioException) {
+                this.ioException = ioException;
+                return this;
+            }
+
+            public Builder setInterrupt(InterruptedException interrupt) {
+                this.interrupt = interrupt;
+                return this;
+            }
+
+            public Builder setSuccesses(Map<BoxedByteArray, byte[]> successes) {
+                this.successes = successes;
+                return this;
+            }
+
+            public CubeIncrementResults build() {
+                return new CubeIncrementResults(ioException, interrupt, ImmutableMap.copyOf(successes));
+            }
+
+            public CubeIncrementResults.Builder add(CubeIncrementResults cubeIncrementResults) {
+                setInterrupt(cubeIncrementResults.interrupt);
+                setIoException(cubeIncrementResults.ioException);
+                setSuccesses(ImmutableMap.<BoxedByteArray, byte[]>builder()
+                        .putAll(successes)
+                        .putAll(cubeIncrementResults.successes)
+                        .build());
+                return this;
+            }
+        }
+    }
+
+
+    private class IncrementerMetrics {
+        private final Histogram incrementSize;
+        private final Histogram incrementFailuresPerFlush;
+        private final Histogram batchesPerFlushHisto;
+        private final Timer batchWritesTimer;
+
+        public IncrementerMetrics(Class clazz, String metricsScope) {
+            incrementSize = Metrics.histogram(clazz, "incrementSize", metricsScope);
+            incrementFailuresPerFlush = Metrics.histogram(clazz, "failuresPerFlush", metricsScope);
+            batchesPerFlushHisto = Metrics.histogram(clazz, "batchesPerFlush", metricsScope);
+            batchWritesTimer = Metrics.timer(clazz, "batchWrites", metricsScope);
+        }
+    }
+}

--- a/src/main/java/com/urbanairship/datacube/idservices/MapIdService.java
+++ b/src/main/java/com/urbanairship/datacube/idservices/MapIdService.java
@@ -24,11 +24,11 @@ import java.util.Optional;
 public class MapIdService implements IdService {
     private static final Logger log = LoggerFactory.getLogger(MapIdService.class);
 
-    private final Map<Integer, Map<BoxedByteArray, Long>> idMap = Maps.newHashMap();
-    private final Map<Integer, Long> nextIds = Maps.newHashMap();
+    private final Map<Integer, Map<BoxedByteArray, Long>> idMap = Maps.newConcurrentMap();
+    private final Map<Integer, Long> nextIds = Maps.newConcurrentMap();
 
     @Override
-    public byte[] getOrCreateId(int dimensionNum, byte[] bytes, int numBytes) {
+    synchronized public byte[] getOrCreateId(int dimensionNum, byte[] bytes, int numBytes) {
         Validate.validateDimensionNum(dimensionNum);
         Validate.validateNumIdBytes(numBytes);
 
@@ -39,7 +39,7 @@ public class MapIdService implements IdService {
             if (log.isDebugEnabled()) {
                 log.debug("Creating new id map for dimension " + dimensionNum);
             }
-            idMapForDimension = Maps.newHashMap();
+            idMapForDimension = Maps.newConcurrentMap();
             idMap.put(dimensionNum, idMapForDimension);
         }
 
@@ -75,7 +75,7 @@ public class MapIdService implements IdService {
     }
 
     @Override
-    public Optional<byte[]> getId(int dimensionNum, byte[] bytes, int numIdBytes) throws IOException, InterruptedException {
+    synchronized public Optional<byte[]> getId(int dimensionNum, byte[] bytes, int numIdBytes) throws IOException, InterruptedException {
         Validate.validateDimensionNum(dimensionNum);
         Validate.validateNumIdBytes(numIdBytes);
 

--- a/src/test/java/com/urbanairship/datacube/MockHbaseHbaseDbHarnessTest.java
+++ b/src/test/java/com/urbanairship/datacube/MockHbaseHbaseDbHarnessTest.java
@@ -15,6 +15,8 @@ import org.apache.hadoop.hbase.client.HTableInterface;
 import org.apache.hadoop.hbase.client.HTablePool;
 import org.apache.hadoop.hbase.client.Increment;
 import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.RetriesExhaustedWithDetailsException;
+import org.apache.hadoop.hbase.client.Row;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
@@ -22,13 +24,16 @@ import org.joda.time.DateTime;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyList;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -37,8 +42,18 @@ import static org.mockito.Mockito.when;
 public class MockHbaseHbaseDbHarnessTest {
     private static final Logger log = LogManager.getLogger(MockHbaseHbaseDbHarnessTest.class);
 
-    private byte[] CUBE_DATA_TABLE = "table".getBytes();
+    private byte[] CUBE_DATA_TABLE = "t".getBytes();
     private byte[] CF = "c".getBytes();
+
+    private HbaseDbHarnessConfiguration config = HbaseDbHarnessConfiguration.newBuilder()
+            .setBatchSize(5)
+            .setNumIoeTries(15)
+            .setUniqueCubeName(new byte[]{})
+            .setTableName(CUBE_DATA_TABLE)
+            .setCf(CF)
+            .setCommitType(DbHarness.CommitType.INCREMENT)
+            .build();
+
 
     @Test
     public void test() throws Exception {
@@ -51,34 +66,39 @@ public class MockHbaseHbaseDbHarnessTest {
 
         when(pool.getTable(any(byte[].class))).thenReturn(htableInterface);
         long value = 10L;
-        when(htableInterface.batch(anyList()))
-                .thenAnswer(a -> {
-                    List<Increment> arguments = (List<Increment>) a.getArguments()[0];
-                    int size = arguments.size();
-                    Object[] objects = new Object[size];
+        doAnswer(a -> {
+            List<Increment> increments = (List<Increment>) a.getArguments()[0];
+            Object[] objects = (Object[]) a.getArguments()[1];
 
-                    for (int i = 0; i < size; ++i) {
-                        incrementOperations.add(arguments.get(i));
-                        if (i % 2 == 1) {
-                            objects[i] = null;
-                        }
-                        objects[i] = new Result(new KeyValue[]{new KeyValue(
-                                arguments.get(i).getRow(),
-                                CF,
-                                HBaseDbHarness.QUALIFIER,
-                                Longs.toByteArray(value)
-                        )});
-                    }
-                    return objects;
-                });
+            int size = increments.size();
 
-        HbaseDbHarnessConfiguration config = HbaseDbHarnessConfiguration.newBuilder()
-                .setBatchSize(2)
-                .setUniqueCubeName(new byte[]{})
-                .setTableName(CUBE_DATA_TABLE)
-                .setCf(CF)
-                .setCommitType(DbHarness.CommitType.INCREMENT)
-                .build();
+            List<Row> failedOperations = new ArrayList<>();
+            List<Throwable> throwables = new ArrayList<>();
+            List<String> hosts = new ArrayList<>();
+
+            for (int i = 0; i < size; ++i) {
+                if (i % 2 == 1) {
+                    failedOperations.add(increments.get(i));
+                    throwables.add(new IOException("ughhh " + i));
+                    hosts.add("host: " + i);
+                    objects[i] = null;
+                } else {
+                    incrementOperations.add(increments.get(i));
+
+                    objects[i] = new Result(new KeyValue[]{new KeyValue(
+                            increments.get(i).getRow(),
+                            CF,
+                            HBaseDbHarness.QUALIFIER,
+                            Longs.toByteArray(value)
+                    )});
+                }
+            }
+
+            if (!failedOperations.isEmpty()) {
+                throw new RetriesExhaustedWithDetailsException(throwables, failedOperations, hosts);
+            }
+            return objects;
+        }).when(htableInterface).batch(anyList(), any(Object[].class));
 
         DbHarness<LongOp> hbaseDbHarness = new HBaseDbHarness<LongOp>(config, pool, LongOp.DESERIALIZER, idService, (avoid) -> null);
 
@@ -101,27 +121,43 @@ public class MockHbaseHbaseDbHarnessTest {
                 dayRollup);
 
         DataCube<LongOp> cube = new DataCube<LongOp>(dimensions, rollups);
+
         WriteBuilder writeBuilder = new WriteBuilder();
+
+        // now, sup: hour and zip rollup
+        // now, sup: day and zip rollup
+        // now, sup: hour rollup
+        // now, sup: day rollup
+        // => 4 writes
         Batch<LongOp> writes = cube.getWrites(writeBuilder
                         .at(time, DateTime.now())
                         .at(zipcode, "sup"),
                 new LongOp(10)
         );
 
-        hbaseDbHarness.runBatchAsync(writes, new AfterExecute<LongOp>() {
-            @Override
-            public void afterExecute(Throwable t) {
-                throw new RuntimeException(t);
-            }
-        });
+        // yesterday, sup: hour and zip rollup
+        // yesterday, sup: day and zip rollup
+        // yesterday, sup: hour rollup
+        // yesterday, sup: day rollup
+        // => 4 writes
+        writes.putAll(cube.getWrites(writeBuilder
+                        .at(time, DateTime.now().minusDays(1))
+                        .at(zipcode, "sup"),
+                new LongOp(10)
+        ));
 
-        hbaseDbHarness.shutdown();
+        // yesterday, ok: hour and zip rollup
+        // yesterday, ok: day and zip rollup
+        // REPEAT: yesterday, ok: hour rollup
+        // REPEAT: yesterday, ok: day rollup
+        // => 2 writes
+        writes.putAll(cube.getWrites(writeBuilder
+                        .at(time, DateTime.now().minusDays(1))
+                        .at(zipcode, "ok"),
+                new LongOp(10)
+        ));
 
-        int size = writes.getMap().size();
-
-        List<BoxedByteArray> result = incrementOperations.stream().map(Increment::getRow)
-                .sorted((a, b) -> Bytes.BYTES_COMPARATOR.compare(a, b))
-                .map(BoxedByteArray::new).collect(Collectors.toList());
+        log.info(writes.getMap().size());
 
         List<BoxedByteArray> expected = writes.getMap().keySet()
                 .stream()
@@ -134,15 +170,48 @@ public class MockHbaseHbaseDbHarnessTest {
                         throw new RuntimeException(e);
                     }
                 })
+                .sorted((a, b) -> Bytes.BYTES_COMPARATOR.compare(a, b))
                 .map(BoxedByteArray::new)
-                .sorted((a, b) -> Bytes.BYTES_COMPARATOR.compare(a.bytes, b.bytes))
                 .collect(Collectors.toList());
 
+
+        hbaseDbHarness.runBatchAsync(writes, new AfterExecute<LongOp>() {
+            @Override
+            public void afterExecute(Throwable t) {
+                throw new RuntimeException(t);
+            }
+        });
+
+        hbaseDbHarness.shutdown();
+
+        List<BoxedByteArray> result = incrementOperations.stream().map(Increment::getRow)
+                .sorted((a, b) -> Bytes.BYTES_COMPARATOR.compare(a, b))
+                .map(BoxedByteArray::new).collect(Collectors.toList());
+
         assertEquals(expected, result);
+        assertEquals(incrementOperations.size(), expected.size());
 
-        assertEquals(incrementOperations.size(), size);
+        verify(htableInterface, times(computeTimes(expected.size(), 2, config.batchSize))).batch(anyList(), any(Object[].class));
+    }
 
-        verify(htableInterface, times(size / config.batchSize)).batch(anyList());
+    public int computeTimes(final int size, int divisor, int batcheSize) {
+        int tempSize = size;
+        int count = 0;
+        while (tempSize > 0) {
+            count++;
+            for (int i = 0; i < size; ++i) {
+                if (i % divisor == 1) {
+                    tempSize--;
+                }
+            }
+        }
+
+        int batches = size / batcheSize;
+
+
+        log.info("Ran " + count);
+
+        return count * (batches) + 1;
     }
 
     private Result getResult(long value) {

--- a/src/test/java/com/urbanairship/datacube/MockHbaseHbaseDbHarnessTest.java
+++ b/src/test/java/com/urbanairship/datacube/MockHbaseHbaseDbHarnessTest.java
@@ -2,6 +2,9 @@ package com.urbanairship.datacube;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.primitives.Longs;
+import com.urbanairship.datacube.bucketers.HourDayMonthBucketer;
+import com.urbanairship.datacube.bucketers.StringToBytesBucketer;
+import com.urbanairship.datacube.dbharnesses.AfterExecute;
 import com.urbanairship.datacube.dbharnesses.HBaseDbHarness;
 import com.urbanairship.datacube.dbharnesses.HbaseDbHarnessConfiguration;
 import com.urbanairship.datacube.idservices.MapIdService;
@@ -10,21 +13,29 @@ import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.HTableInterface;
 import org.apache.hadoop.hbase.client.HTablePool;
+import org.apache.hadoop.hbase.client.Increment;
 import org.apache.hadoop.hbase.client.Result;
-import org.apache.hadoop.hbase.client.Row;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.log4j.LogManager;
+import org.apache.log4j.Logger;
+import org.joda.time.DateTime;
 import org.junit.Test;
 
+import java.io.IOException;
+import java.util.LinkedList;
 import java.util.List;
+import java.util.stream.Collectors;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyList;
-import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class MockHbaseHbaseDbHarnessTest {
+    private static final Logger log = LogManager.getLogger(MockHbaseHbaseDbHarnessTest.class);
 
     private byte[] CUBE_DATA_TABLE = "table".getBytes();
     private byte[] CF = "c".getBytes();
@@ -36,14 +47,18 @@ public class MockHbaseHbaseDbHarnessTest {
         HTablePool pool = mock(HTablePool.class);
         HTableInterface htableInterface = mock(HTableInterface.class);
 
+        final List<Increment> incrementOperations = new LinkedList<>();
+
         when(pool.getTable(any(byte[].class))).thenReturn(htableInterface);
+        long value = 10L;
         when(htableInterface.batch(anyList()))
                 .thenAnswer(a -> {
-                    List<Row> arguments = (List<Row>) a.getArguments()[0];
+                    List<Increment> arguments = (List<Increment>) a.getArguments()[0];
                     int size = arguments.size();
                     Object[] objects = new Object[size];
 
                     for (int i = 0; i < size; ++i) {
+                        incrementOperations.add(arguments.get(i));
                         if (i % 2 == 1) {
                             objects[i] = null;
                         }
@@ -51,15 +66,15 @@ public class MockHbaseHbaseDbHarnessTest {
                                 arguments.get(i).getRow(),
                                 CF,
                                 HBaseDbHarness.QUALIFIER,
-                                Longs.toByteArray(10L)
+                                Longs.toByteArray(value)
                         )});
                     }
                     return objects;
                 });
 
         HbaseDbHarnessConfiguration config = HbaseDbHarnessConfiguration.newBuilder()
-                .setBatchSize(100)
-                .setUniqueCubeName("hbaseForCubeDataTest".getBytes())
+                .setBatchSize(2)
+                .setUniqueCubeName(new byte[]{})
                 .setTableName(CUBE_DATA_TABLE)
                 .setCf(CF)
                 .setCommitType(DbHarness.CommitType.INCREMENT)
@@ -67,9 +82,67 @@ public class MockHbaseHbaseDbHarnessTest {
 
         DbHarness<LongOp> hbaseDbHarness = new HBaseDbHarness<LongOp>(config, pool, LongOp.DESERIALIZER, idService, (avoid) -> null);
 
-        when(htableInterface.get(any(Get.class))).thenReturn(getResult(10L), getResult(10L), getResult(100L));
-        DbHarnessTests.asyncBatchWritesTest(hbaseDbHarness, 10);
-        verify(htableInterface, atLeast(2)).batch(anyList());
+        when(htableInterface.get(any(Get.class))).thenReturn(getResult(value), getResult(value), getResult(100L));
+
+        HourDayMonthBucketer hourDayMonthBucketer = new HourDayMonthBucketer();
+
+        Dimension<DateTime> time = new Dimension<DateTime>("time", hourDayMonthBucketer, false, 8);
+        Dimension<String> zipcode = new Dimension<String>("zipcode", new StringToBytesBucketer(),
+                true, 5);
+
+
+        Rollup hourAndZipRollup = new Rollup(zipcode, time, HourDayMonthBucketer.hours);
+        Rollup dayAndZipRollup = new Rollup(zipcode, time, HourDayMonthBucketer.days);
+        Rollup hourRollup = new Rollup(time, HourDayMonthBucketer.hours);
+        Rollup dayRollup = new Rollup(time, HourDayMonthBucketer.days);
+
+        List<Dimension<?>> dimensions = ImmutableList.<Dimension<?>>of(time, zipcode);
+        List<Rollup> rollups = ImmutableList.of(hourAndZipRollup, dayAndZipRollup, hourRollup,
+                dayRollup);
+
+        DataCube<LongOp> cube = new DataCube<LongOp>(dimensions, rollups);
+        WriteBuilder writeBuilder = new WriteBuilder();
+        Batch<LongOp> writes = cube.getWrites(writeBuilder
+                        .at(time, DateTime.now())
+                        .at(zipcode, "sup"),
+                new LongOp(10)
+        );
+
+        hbaseDbHarness.runBatchAsync(writes, new AfterExecute<LongOp>() {
+            @Override
+            public void afterExecute(Throwable t) {
+                throw new RuntimeException(t);
+            }
+        });
+
+        hbaseDbHarness.shutdown();
+
+        int size = writes.getMap().size();
+
+        List<BoxedByteArray> result = incrementOperations.stream().map(Increment::getRow)
+                .sorted((a, b) -> Bytes.BYTES_COMPARATOR.compare(a, b))
+                .map(BoxedByteArray::new).collect(Collectors.toList());
+
+        List<BoxedByteArray> expected = writes.getMap().keySet()
+                .stream()
+                .map(a -> {
+                    try {
+                        return a.toWriteKey(idService);
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    } catch (InterruptedException e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+                .map(BoxedByteArray::new)
+                .sorted((a, b) -> Bytes.BYTES_COMPARATOR.compare(a.bytes, b.bytes))
+                .collect(Collectors.toList());
+
+        assertEquals(expected, result);
+
+        assertEquals(incrementOperations.size(), size);
+
+        verify(htableInterface, times(size / config.batchSize)).batch(anyList());
     }
 
     private Result getResult(long value) {

--- a/src/test/java/com/urbanairship/datacube/MockHbaseHbaseDbHarnessTest.java
+++ b/src/test/java/com/urbanairship/datacube/MockHbaseHbaseDbHarnessTest.java
@@ -196,9 +196,6 @@ public class MockHbaseHbaseDbHarnessTest {
 
         int batches = size / batcheSize;
 
-
-        log.info("Ran " + count);
-
         return count * (batches) + 1;
     }
 


### PR DESCRIPTION
Deploying batch increment operation code revealed some problems

- we were logging the wrapper exception, which did not have enough
  detail to diagnose problems
- we were reusing a map which was supposed to be used once per iteration,
  which cause over-counts
- The batch method we were calling appears to be deprecated in the
  modern version of hbase actually run at UA

This also moves all the batch increment specific code to a package local class called HbaseBatchIncrementer, for code organization purposes only.