### PR TITLE
Add a result parser factory for hbase db harness

### DIFF
--- a/src/main/java/com/urbanairship/datacube/dbharnesses/SingleColumnParser.java
+++ b/src/main/java/com/urbanairship/datacube/dbharnesses/SingleColumnParser.java
@@ -1,0 +1,15 @@
+package com.urbanairship.datacube.dbharnesses;
+
+import com.urbanairship.datacube.Deserializer;
+import com.urbanairship.datacube.Op;
+import org.apache.hadoop.hbase.client.Result;
+
+import java.util.function.Function;
+
+public class SingleColumnParser<T extends Op> implements Function<Deserializer<T>, Function<Result, T>> {
+
+    @Override
+    public Function<Result, T> apply(Deserializer<T> deserializer) {
+        return result -> deserializer.fromBytes(result.value());
+    }
+}

--- a/src/test/java/com/urbanairship/datacube/HBaseHarnessTest.java
+++ b/src/test/java/com/urbanairship/datacube/HBaseHarnessTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableList;
 import com.urbanairship.datacube.bucketers.HourDayMonthBucketer;
 import com.urbanairship.datacube.bucketers.StringToBytesBucketer;
 import com.urbanairship.datacube.dbharnesses.HBaseDbHarness;
+import com.urbanairship.datacube.dbharnesses.SingleColumnParser;
 import com.urbanairship.datacube.idservices.MapIdService;
 import com.urbanairship.datacube.ops.LongOp;
 import org.apache.hadoop.hbase.client.HTablePool;
@@ -68,7 +69,8 @@ public class HBaseHarnessTest extends EmbeddedClusterTestAbstract {
         HTablePool pool = new HTablePool(getTestUtil().getConfiguration(), Integer.MAX_VALUE);
         DbHarness<LongOp> hbaseDbHarness = new HBaseDbHarness<LongOp>(pool,
                 "dh" .getBytes(), DATA_CUBE_TABLE, CF, LongOp.DESERIALIZER, idService,
-                DbHarness.CommitType.INCREMENT, new TestCallback(s), 1, 1, 1, "none", this.batchSize);
+                DbHarness.CommitType.INCREMENT, new TestCallback(s), 1, 1, 1, "none", this.batchSize,
+                new SingleColumnParser<>());
         // Do an increment of 5 for a certain time and zipcode
         DataCubeIo<LongOp> dataCubeIo = new DataCubeIo<LongOp>(dataCube, hbaseDbHarness, 1, 100000,
                 SyncLevel.BATCH_SYNC, "scope", true);
@@ -108,7 +110,8 @@ public class HBaseHarnessTest extends EmbeddedClusterTestAbstract {
         HTablePool pool = new HTablePool(getTestUtil().getConfiguration(), Integer.MAX_VALUE);
         DbHarness<LongOp> hbaseDbHarness = new HBaseDbHarness<LongOp>(pool,
                 "dh" .getBytes(), DATA_CUBE_TABLE, CF, LongOp.DESERIALIZER, idService,
-                DbHarness.CommitType.INCREMENT, (ignored) -> null, 1, 1, 1,"none", this.batchSize);
+                DbHarness.CommitType.INCREMENT, (ignored) -> null, 1, 1, 1,"none", this.batchSize,
+                new SingleColumnParser<>());
 
         DataCubeIo<LongOp> dataCubeIo = new DataCubeIo<LongOp>(dataCube, hbaseDbHarness, 1, 100000,
                 SyncLevel.BATCH_SYNC, "scope", true);


### PR DESCRIPTION
Abstracts the parsing and deserialization of HBase results, allowing for
alternative implementations (ex. more than one qualifier per row).

The standard funtionality of taking the first column in a result is
preserved via the usage of the `SimpleColumnParser` class.